### PR TITLE
Rename module and update for XS 8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/terra-farm/terraform-provider-xenserver
+module github.com/xenserver/terraform-provider-xenserver
 
 go 1.16
 
@@ -31,7 +31,7 @@ require (
 	github.com/mitchellh/mapstructure v1.4.2 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/posener/complete v1.2.3 // indirect
-	github.com/terra-farm/go-xen-api-client v0.0.2
+	github.com/sarah-soo/go-xen-api-client v1.0.0
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/vmihailenco/tagparser v0.1.2 // indirect
 	github.com/zclconf/go-cty v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -383,6 +383,9 @@ github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSg
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/sarah-soo/go-xen-api-client v1.0.0 h1:TPvd5c37++lVJ+uCBBayAtVOjWa0pfslvlLR42F0n/U=
+github.com/sarah-soo/go-xen-api-client v1.0.0/go.mod h1:UENdtu2T9eARL+PTwb8/rFe/t3+W+rGAm69+oai9kkc=
+github.com/serenize/snaker v0.0.0-20201027110005-a7ad2135616e/go.mod h1:Yow6lPLSAXx2ifx470yD/nUe22Dv5vBvxK/UK9UUTVs=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
@@ -406,8 +409,6 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/terra-farm/go-xen-api-client v0.0.2 h1:EREW0N6XqU935b005yCwbPjm8F6582j2rI5C4ew3ZTQ=
-github.com/terra-farm/go-xen-api-client v0.0.2/go.mod h1:L7+Ea6rxzK7AL4DhcEPDQxdLKb4wKq0sYbxHS2ag9YE=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/terra-farm/terraform-provider-xenserver/xenserver"
+	"github.com/xenserver/terraform-provider-xenserver/xenserver"
 )
 
 func main() {

--- a/xenserver/config.go
+++ b/xenserver/config.go
@@ -1,7 +1,7 @@
 package xenserver
 
 import (
-	xenapi "github.com/terra-farm/go-xen-api-client"
+	xenapi "github.com/sarah-soo/go-xen-api-client"
 )
 
 // Config ...

--- a/xenserver/resource_network.go
+++ b/xenserver/resource_network.go
@@ -22,7 +22,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	xenapi "github.com/terra-farm/go-xen-api-client"
+	xenapi "github.com/sarah-soo/go-xen-api-client"
 )
 
 const (

--- a/xenserver/resource_vbd.go
+++ b/xenserver/resource_vbd.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	xenapi "github.com/terra-farm/go-xen-api-client"
+	xenapi "github.com/sarah-soo/go-xen-api-client"
 )
 
 const (

--- a/xenserver/resource_vdi.go
+++ b/xenserver/resource_vdi.go
@@ -22,7 +22,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	xenapi "github.com/terra-farm/go-xen-api-client"
+	xenapi "github.com/sarah-soo/go-xen-api-client"
 )
 
 const (
@@ -165,16 +165,6 @@ func resourceVDIUpdate(d *schema.ResourceData, m interface{}) error {
 		}
 
 		d.SetPartial(vdiSchemaName)
-	}
-
-	if d.HasChange(vdiSchemaSize) {
-		_, n := d.GetChange(vdiSchemaSize)
-
-		if err := c.client.VDI.SetVirtualSize(c.session, vdi.VDIRef, n.(int)); err != nil {
-			return err
-		}
-
-		d.SetPartial(vdiSchemaSize)
 	}
 
 	if d.HasChange(vdiSchemaShared) {

--- a/xenserver/resource_vif.go
+++ b/xenserver/resource_vif.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	xenapi "github.com/terra-farm/go-xen-api-client"
+	xenapi "github.com/sarah-soo/go-xen-api-client"
 )
 
 const (

--- a/xenserver/resource_vlan.go
+++ b/xenserver/resource_vlan.go
@@ -22,7 +22,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	xenapi "github.com/terra-farm/go-xen-api-client"
+	xenapi "github.com/sarah-soo/go-xen-api-client"
 )
 
 const (

--- a/xenserver/resource_vm.go
+++ b/xenserver/resource_vm.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	xenapi "github.com/terra-farm/go-xen-api-client"
+	xenapi "github.com/sarah-soo/go-xen-api-client"
 )
 
 const (

--- a/xenserver/types.go
+++ b/xenserver/types.go
@@ -23,7 +23,7 @@ import (
 	"log"
 	"strconv"
 
-	xenapi "github.com/terra-farm/go-xen-api-client"
+	xenapi "github.com/sarah-soo/go-xen-api-client"
 )
 
 type Range struct {
@@ -508,10 +508,6 @@ func (this *VBDDescriptor) Query(c *Connection) error {
 
 	vdi := &VDIDescriptor{
 		VDIRef: vbd.VDI,
-	}
-
-	if err := vdi.Query(c); err != nil {
-		return err
 	}
 
 	this.VDI = vdi


### PR DESCRIPTION
* Rename module to **xenserver**/terraform-provider-xenserver
* Switch go-xen-api-client to sarah-soo fork (updated for XenServer 8)
* Update provider for XenServer 8