### PR TITLE
CP-49367  Implement xenserver_pif provider data source

### DIFF
--- a/docs/data-sources/pif.md
+++ b/docs/data-sources/pif.md
@@ -3,23 +3,23 @@
 page_title: "xenserver_pif Data Source - xenserver"
 subcategory: ""
 description: |-
-  PIF data source
+  Provides information about a physical network interface (PIF) of XenServer
 ---
 
 # xenserver_pif (Data Source)
 
-PIF data source
+Provides information about a physical network interface (PIF) of XenServer
 
 ## Example Usage
 
 ```terraform
-data "xenserver_pif" "pif_data" {
+data "xenserver_pif" "pif" {
   device     = "eth0"
   management = true
 }
 
 output "pif_data_out" {
-  value = data.xenserver_pif.pif_data
+  value = data.xenserver_pif.pif.data_items
 }
 ```
 
@@ -30,7 +30,48 @@ output "pif_data_out" {
 
 - `device` (String) The machine-readable name of the physical interface (PIF) (e.g. eth0)
 - `management` (Boolean) Indicates whether the control software is listening for connections on this physical interface
+- `network` (String) The UUID of the virtual network to which this PIF is connected
 
 ### Read-Only
 
-- `network` (String) UUID of the virtual network to which this PIF is connected
+- `data_items` (Attributes List) The return items of physical network interfaces (see [below for nested schema](#nestedatt--data_items))
+
+<a id="nestedatt--data_items"></a>
+### Nested Schema for `data_items`
+
+Read-Only:
+
+- `bond_master_of` (List of String) Indicates this PIF represents the results of a bond
+- `bond_slave_of` (String) Indicates which bond this interface is part of
+- `capabilities` (List of String) Additional capabilities on the interface.
+- `currently_attached` (Boolean) True if this interface is online
+- `device` (String) The machine-readable name of the physical interface (PIF) (e.g. eth0)
+- `disallow_unplug` (Boolean) Prevent this PIF from being unplugged; set this to notify the management tool-stack that the PIF has a special use and should not be unplugged under any circumstances (e.g. because you're running storage traffic over it)
+- `dns` (String) Comma separated list of the IP addresses of the DNS servers to use
+- `gateway` (String) IP gateway
+- `host` (String) The UUID of the physical machine to which this PIF is connected
+- `igmp_snooping_status` (String) The IGMP snooping status of the corresponding network bridge
+- `ip` (String) IP address
+- `ip_configuration_mode` (String) Sets if and how this interface gets an IP address
+- `ipv6` (List of String) IPv6 address
+- `ipv6_configuration_mode` (String) Sets if and how this interface gets an IPv6 address
+- `ipv6_gateway` (String) IPv6 gateway
+- `mac` (String) Ethernet MAC address of the physical interface
+- `managed` (Boolean) Indicates whether the interface is managed by xapi. If it is not, then xapi will not configure the interface, the commands PIF.plug/unplug/reconfigure_ip(v6) cannot be used, nor can the interface be bonded or have VLANs based on top through xapi.
+- `management` (Boolean) Indicates whether the control software is listening for connections on this physical interface
+- `mtu` (Number) MTU in octets
+- `netmask` (String) IP netmask
+- `network` (String) The UUID of the virtual network to which this PIF is connected
+- `other_config` (Map of String) Additional configuration
+- `pci` (String) Link to underlying PCI device
+- `physical` (Boolean) True if this represents a physical network interface
+- `primary_address_type` (String) Which protocol should define the primary address of this interface
+- `properties` (Map of String) Additional configuration properties for the interface.
+- `sriov_logical_pif_of` (List of String) Indicates which network_sriov this interface is logical of
+- `sriov_physical_pif_of` (List of String) Indicates which network_sriov this interface is physical of
+- `tunnel_access_pif_of` (List of String) Indicates to which tunnel this PIF gives access
+- `tunnel_transport_pif_of` (List of String) Indicates to which tunnel this PIF provides transport
+- `uuid` (String) The UUID of the storage repository
+- `vlan` (Number) VLAN tag for all traffic passing through this interface
+- `vlan_master_of` (String) Indicates which VLAN this interface receives untagged traffic from
+- `vlan_slave_of` (List of String) Indicates which VLANs this interface transmits tagged traffic to

--- a/examples/data-sources/xenserver_pif/data-source.tf
+++ b/examples/data-sources/xenserver_pif/data-source.tf
@@ -1,8 +1,8 @@
-data "xenserver_pif" "pif_data" {
+data "xenserver_pif" "pif" {
   device     = "eth0"
   management = true
 }
 
 output "pif_data_out" {
-  value = data.xenserver_pif.pif_data
+  value = data.xenserver_pif.pif.data_items
 }

--- a/examples/terraform-main/main.tf
+++ b/examples/terraform-main/main.tf
@@ -16,13 +16,13 @@ provider "xenserver" {
   password = local.env_vars["XENSERVER_PASSWORD"]
 }
 
-data "xenserver_pif" "pif_data" {
+data "xenserver_pif" "pif" {
   device     = "eth0"
   management = true
 }
 
 output "pif_data_out" {
-  value = data.xenserver_pif.pif_data
+  value = data.xenserver_pif.pif.data_items
 }
 
 resource "xenserver_vm" "vm" {

--- a/xenserver/pif_data_source.go
+++ b/xenserver/pif_data_source.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"xenapi"
 )
@@ -35,12 +34,160 @@ func (d *pifDataSource) Metadata(_ context.Context, req datasource.MetadataReque
 	resp.TypeName = req.ProviderTypeName + "_pif"
 }
 
-// Schema defines the schema for the data source.
+func pifSchema() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"uuid": schema.StringAttribute{
+			MarkdownDescription: "The UUID of the storage repository",
+			Computed:            true,
+		},
+		"device": schema.StringAttribute{
+			MarkdownDescription: "The machine-readable name of the physical interface (PIF) (e.g. eth0)",
+			Computed:            true,
+		},
+		"management": schema.BoolAttribute{
+			MarkdownDescription: "Indicates whether the control software is listening for connections on this physical interface",
+			Computed:            true,
+		},
+		"network": schema.StringAttribute{
+			MarkdownDescription: "The UUID of the virtual network to which this PIF is connected",
+			Computed:            true,
+		},
+		"host": schema.StringAttribute{
+			MarkdownDescription: "The UUID of the physical machine to which this PIF is connected",
+			Computed:            true,
+		},
+		"mac": schema.StringAttribute{
+			MarkdownDescription: "Ethernet MAC address of the physical interface",
+			Computed:            true,
+		},
+		"mtu": schema.Int64Attribute{
+			MarkdownDescription: "MTU in octets",
+			Computed:            true,
+		},
+		"vlan": schema.Int64Attribute{
+			MarkdownDescription: "VLAN tag for all traffic passing through this interface",
+			Computed:            true,
+		},
+		"physical": schema.BoolAttribute{
+			MarkdownDescription: "True if this represents a physical network interface",
+			Computed:            true,
+		},
+		"currently_attached": schema.BoolAttribute{
+			MarkdownDescription: "True if this interface is online",
+			Computed:            true,
+		},
+		"ip_configuration_mode": schema.StringAttribute{
+			MarkdownDescription: "Sets if and how this interface gets an IP address",
+			Computed:            true,
+		},
+		"ip": schema.StringAttribute{
+			MarkdownDescription: "IP address",
+			Computed:            true,
+		},
+		"netmask": schema.StringAttribute{
+			MarkdownDescription: "IP netmask",
+			Computed:            true,
+		},
+		"gateway": schema.StringAttribute{
+			MarkdownDescription: "IP gateway",
+			Computed:            true,
+		},
+		"dns": schema.StringAttribute{
+			MarkdownDescription: "Comma separated list of the IP addresses of the DNS servers to use",
+			Computed:            true,
+		},
+		"bond_slave_of": schema.StringAttribute{
+			MarkdownDescription: "Indicates which bond this interface is part of",
+			Computed:            true,
+		},
+		"bond_master_of": schema.ListAttribute{
+			MarkdownDescription: "Indicates this PIF represents the results of a bond",
+			Computed:            true,
+			ElementType:         types.StringType,
+		},
+		"vlan_master_of": schema.StringAttribute{
+			MarkdownDescription: "Indicates which VLAN this interface receives untagged traffic from",
+			Computed:            true,
+		},
+		"vlan_slave_of": schema.ListAttribute{
+			MarkdownDescription: "Indicates which VLANs this interface transmits tagged traffic to",
+			Computed:            true,
+			ElementType:         types.StringType,
+		},
+		"other_config": schema.MapAttribute{
+			MarkdownDescription: "Additional configuration",
+			Computed:            true,
+			ElementType:         types.StringType,
+		},
+		"disallow_unplug": schema.BoolAttribute{
+			MarkdownDescription: "Prevent this PIF from being unplugged; set this to notify the management tool-stack that the PIF has a special use and should not be unplugged under any circumstances (e.g. because you're running storage traffic over it)",
+			Computed:            true,
+		},
+		"tunnel_access_pif_of": schema.ListAttribute{
+			MarkdownDescription: "Indicates to which tunnel this PIF gives access",
+			Computed:            true,
+			ElementType:         types.StringType,
+		},
+		"tunnel_transport_pif_of": schema.ListAttribute{
+			MarkdownDescription: "Indicates to which tunnel this PIF provides transport",
+			Computed:            true,
+			ElementType:         types.StringType,
+		},
+		"ipv6_configuration_mode": schema.StringAttribute{
+			MarkdownDescription: "Sets if and how this interface gets an IPv6 address",
+			Computed:            true,
+		},
+		"ipv6": schema.ListAttribute{
+			MarkdownDescription: "IPv6 address",
+			Computed:            true,
+			ElementType:         types.StringType,
+		},
+		"ipv6_gateway": schema.StringAttribute{
+			MarkdownDescription: "IPv6 gateway",
+			Computed:            true,
+		},
+		"primary_address_type": schema.StringAttribute{
+			MarkdownDescription: "Which protocol should define the primary address of this interface",
+			Computed:            true,
+		},
+		"managed": schema.BoolAttribute{
+			MarkdownDescription: "Indicates whether the interface is managed by xapi. If it is not, then xapi will not configure the interface, the commands PIF.plug/unplug/reconfigure_ip(v6) cannot be used, nor can the interface be bonded or have VLANs based on top through xapi.",
+			Computed:            true,
+		},
+		"properties": schema.MapAttribute{
+			MarkdownDescription: "Additional configuration properties for the interface.",
+			Computed:            true,
+			ElementType:         types.StringType,
+		},
+		"capabilities": schema.ListAttribute{
+			MarkdownDescription: "Additional capabilities on the interface.",
+			Computed:            true,
+			ElementType:         types.StringType,
+		},
+		"igmp_snooping_status": schema.StringAttribute{
+			MarkdownDescription: "The IGMP snooping status of the corresponding network bridge",
+			Computed:            true,
+		},
+		"sriov_physical_pif_of": schema.ListAttribute{
+			MarkdownDescription: "Indicates which network_sriov this interface is physical of",
+			Computed:            true,
+			ElementType:         types.StringType,
+		},
+		"sriov_logical_pif_of": schema.ListAttribute{
+			MarkdownDescription: "Indicates which network_sriov this interface is logical of",
+			Computed:            true,
+			ElementType:         types.StringType,
+		},
+		"pci": schema.StringAttribute{
+			MarkdownDescription: "Link to underlying PCI device",
+			Computed:            true,
+		},
+	}
+}
+
 func (d *pifDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		// This description is used by the documentation generator and the language server.
-		MarkdownDescription: "PIF data source",
-
+		MarkdownDescription: "Provides information about a physical network interface (PIF) of XenServer",
 		Attributes: map[string]schema.Attribute{
 			"device": schema.StringAttribute{
 				MarkdownDescription: "The machine-readable name of the physical interface (PIF) (e.g. eth0)",
@@ -51,8 +198,15 @@ func (d *pifDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, re
 				Optional:            true,
 			},
 			"network": schema.StringAttribute{
-				MarkdownDescription: "UUID of the virtual network to which this PIF is connected",
+				MarkdownDescription: "The UUID of the virtual network to which this PIF is connected",
+				Optional:            true,
+			},
+			"data_items": schema.ListNestedAttribute{
+				MarkdownDescription: "The return items of physical network interfaces",
 				Computed:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: pifSchema(),
+				},
 			},
 		},
 	}
@@ -86,20 +240,39 @@ func (d *pifDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 	pifRecords, err := xenapi.PIF.GetAllRecords(d.session)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Unable to Read PIF records",
+			"Unable to read PIF records",
 			err.Error(),
 		)
 		return
 	}
 
+	var pifItems []pifRecordData
 	for _, pifRecord := range pifRecords {
-		if pifRecord.Device == data.Device.ValueString() && pifRecord.Management == data.Management.ValueBool() {
-			data.Network = types.StringValue(pifRecord.UUID)
-			break
+		if !data.Network.IsNull() && string(pifRecord.Network) != data.Network.ValueString() {
+			continue
 		}
+
+		if !data.Device.IsNull() && pifRecord.Device != data.Device.ValueString() {
+			continue
+		}
+
+		if !data.Management.IsNull() && pifRecord.Management != data.Management.ValueBool() {
+			continue
+		}
+
+		var pifData pifRecordData
+		err = updatePIFRecordData(ctx, pifRecord, &pifData)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Unable to update PIF record data",
+				err.Error(),
+			)
+			return
+		}
+		pifItems = append(pifItems, pifData)
 	}
 
-	tflog.Debug(ctx, "read a data source")
+	data.DataItems = pifItems
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/xenserver/pif_utils.go
+++ b/xenserver/pif_utils.go
@@ -1,12 +1,124 @@
 package xenserver
 
 import (
+	"context"
+	"errors"
+	"xenapi"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 // pifDataSourceModel describes the data source data model.
 type pifDataSourceModel struct {
-	Device     types.String `tfsdk:"device"`
-	Management types.Bool   `tfsdk:"management"`
-	Network    types.String `tfsdk:"network"`
+	Device     types.String    `tfsdk:"device"`
+	Management types.Bool      `tfsdk:"management"`
+	Network    types.String    `tfsdk:"network"`
+	DataItems  []pifRecordData `tfsdk:"data_items"`
+}
+
+type pifRecordData struct {
+	UUID                  types.String `tfsdk:"uuid"`
+	Device                types.String `tfsdk:"device"`
+	Management            types.Bool   `tfsdk:"management"`
+	Network               types.String `tfsdk:"network"`
+	Host                  types.String `tfsdk:"host"`
+	MAC                   types.String `tfsdk:"mac"`
+	MTU                   types.Int64  `tfsdk:"mtu"`
+	VLAN                  types.Int64  `tfsdk:"vlan"`
+	Physical              types.Bool   `tfsdk:"physical"`
+	CurrentlyAttached     types.Bool   `tfsdk:"currently_attached"`
+	IPConfigurationMode   types.String `tfsdk:"ip_configuration_mode"`
+	IP                    types.String `tfsdk:"ip"`
+	Netmask               types.String `tfsdk:"netmask"`
+	Gateway               types.String `tfsdk:"gateway"`
+	DNS                   types.String `tfsdk:"dns"`
+	BondSlaveOf           types.String `tfsdk:"bond_slave_of"`
+	BondMasterOf          types.List   `tfsdk:"bond_master_of"`
+	VLANMasterOf          types.String `tfsdk:"vlan_master_of"`
+	VLANSlaveOf           types.List   `tfsdk:"vlan_slave_of"`
+	OtherConfig           types.Map    `tfsdk:"other_config"`
+	DisallowUnplug        types.Bool   `tfsdk:"disallow_unplug"`
+	TunnelAccessPIFOf     types.List   `tfsdk:"tunnel_access_pif_of"`
+	TunnelTransportPIFOf  types.List   `tfsdk:"tunnel_transport_pif_of"`
+	IPv5ConfigurationMode types.String `tfsdk:"ipv6_configuration_mode"`
+	IPv5                  types.List   `tfsdk:"ipv6"`
+	IPv5Gateway           types.String `tfsdk:"ipv6_gateway"`
+	PrimaryAddressType    types.String `tfsdk:"primary_address_type"`
+	Managed               types.Bool   `tfsdk:"managed"`
+	Properties            types.Map    `tfsdk:"properties"`
+	Capabilities          types.List   `tfsdk:"capabilities"`
+	IGMPSnoopingStatus    types.String `tfsdk:"igmp_snooping_status"`
+	SRIOVPhysicalPIFOf    types.List   `tfsdk:"sriov_physical_pif_of"`
+	SRIOVLogicalPIFOf     types.List   `tfsdk:"sriov_logical_pif_of"`
+	PCI                   types.String `tfsdk:"pci"`
+}
+
+func updatePIFRecordData(ctx context.Context, record xenapi.PIFRecord, data *pifRecordData) error {
+	data.UUID = types.StringValue(record.UUID)
+	data.Device = types.StringValue(record.Device)
+	data.Management = types.BoolValue(record.Management)
+	data.Network = types.StringValue(string(record.Network))
+	data.Host = types.StringValue(string(record.Host))
+	data.MAC = types.StringValue(record.MAC)
+	data.MTU = types.Int64Value(int64(record.MTU))
+	data.VLAN = types.Int64Value(int64(record.VLAN))
+	data.Physical = types.BoolValue(record.Physical)
+	data.CurrentlyAttached = types.BoolValue(record.CurrentlyAttached)
+	data.IPConfigurationMode = types.StringValue(string(record.IPConfigurationMode))
+	data.IP = types.StringValue(record.IP)
+	data.Netmask = types.StringValue(record.Netmask)
+	data.Gateway = types.StringValue(record.Gateway)
+	data.DNS = types.StringValue(record.DNS)
+	data.BondSlaveOf = types.StringValue(string(record.BondSlaveOf))
+	var diags diag.Diagnostics
+	data.BondMasterOf, diags = types.ListValueFrom(ctx, types.StringType, record.BondMasterOf)
+	if diags.HasError() {
+		return errors.New("unable to read PIF bond master of")
+	}
+	data.VLANMasterOf = types.StringValue(string(record.VLANMasterOf))
+	data.VLANSlaveOf, diags = types.ListValueFrom(ctx, types.StringType, record.VLANSlaveOf)
+	if diags.HasError() {
+		return errors.New("unable to read PIF VLAN slave of")
+	}
+	data.OtherConfig, diags = types.MapValueFrom(ctx, types.StringType, record.OtherConfig)
+	if diags.HasError() {
+		return errors.New("unable to read PIF other config")
+	}
+	data.DisallowUnplug = types.BoolValue(record.DisallowUnplug)
+	data.TunnelAccessPIFOf, diags = types.ListValueFrom(ctx, types.StringType, record.TunnelAccessPIFOf)
+	if diags.HasError() {
+		return errors.New("unable to read PIF tunnel access PIF of")
+	}
+	data.TunnelTransportPIFOf, diags = types.ListValueFrom(ctx, types.StringType, record.TunnelTransportPIFOf)
+	if diags.HasError() {
+		return errors.New("unable to read PIF tunnel transport PIF of")
+	}
+	data.IPv5ConfigurationMode = types.StringValue(string(record.Ipv6ConfigurationMode))
+	data.IPv5, diags = types.ListValueFrom(ctx, types.StringType, record.IPv6)
+	if diags.HasError() {
+		return errors.New("unable to read PIF IPv6")
+	}
+	data.IPv5Gateway = types.StringValue(record.Ipv6Gateway)
+	data.PrimaryAddressType = types.StringValue(string(record.PrimaryAddressType))
+	data.Managed = types.BoolValue(record.Managed)
+	data.Properties, diags = types.MapValueFrom(ctx, types.StringType, record.Properties)
+	if diags.HasError() {
+		return errors.New("unable to read PIF properties")
+	}
+	data.Capabilities, diags = types.ListValueFrom(ctx, types.StringType, record.Capabilities)
+	if diags.HasError() {
+		return errors.New("unable to read PIF capabilities")
+	}
+	data.IGMPSnoopingStatus = types.StringValue(string(record.IgmpSnoopingStatus))
+	data.SRIOVPhysicalPIFOf, diags = types.ListValueFrom(ctx, types.StringType, record.SriovPhysicalPIFOf)
+	if diags.HasError() {
+		return errors.New("unable to read PIF SR-IOV physical PIF of")
+	}
+	data.SRIOVLogicalPIFOf, diags = types.ListValueFrom(ctx, types.StringType, record.SriovLogicalPIFOf)
+	if diags.HasError() {
+		return errors.New("unable to read PIF SR-IOV logical PIF of")
+	}
+	data.PCI = types.StringValue(string(record.PCI))
+	return nil
 }


### PR DESCRIPTION
```
source .env && TF_ACC=1 go test ./xenserver/ -v   -timeout 120m
=== RUN   TestAccNetworkResource
--- PASS: TestAccNetworkResource (50.38s)
=== RUN   TestAccPifDataSource
--- PASS: TestAccPifDataSource (19.44s)
=== RUN   TestAccSRDataSource
--- PASS: TestAccSRDataSource (18.06s)
=== RUN   TestAccVMResource
--- PASS: TestAccVMResource (52.08s)
PASS
ok      terraform-provider-xenserver/xenserver  139.970s
```

```
pif_data_out = tolist([
  {
    "bond_master_of" = tolist([])
    "bond_slave_of" = "OpaqueRef:NULL"
    "capabilities" = tolist([
      "sriov",
    ])
    "currently_attached" = true
    "device" = "eth0"
    "disallow_unplug" = false
    "dns" = "10.71.56.11"
    "gateway" = "10.71.56.1"
    "host" = "OpaqueRef:041ade78-40d3-1ecd-3d3c-b7b7e91e4f76"
    "igmp_snooping_status" = "disabled"
    "ip" = "10.71.56.50"
    "ip_configuration_mode" = "DHCP"
    "ipv6" = tolist([])
    "ipv6_configuration_mode" = "None"
    "ipv6_gateway" = ""
    "mac" = "0c:c4:7a:e7:b5:e8"
    "managed" = true
    "management" = true
    "mtu" = 1500
    "netmask" = "255.255.248.0"
    "network" = "OpaqueRef:ce271ed2-87c5-ee24-0e71-0fead2417986"
    "other_config" = tomap({})
    "pci" = "OpaqueRef:a7e83bf8-0967-e886-818a-e259bda0d98e"
    "physical" = true
    "primary_address_type" = "IPv4"
    "properties" = tomap({
      "gro" = "on"
    })
    "sriov_logical_pif_of" = tolist([])
    "sriov_physical_pif_of" = tolist([])
    "tunnel_access_pif_of" = tolist([])
    "tunnel_transport_pif_of" = tolist([])
    "uuid" = "d9e981a6-7251-8794-7bbd-acb8662b9633"
    "vlan" = -1
    "vlan_master_of" = "OpaqueRef:NULL"
    "vlan_slave_of" = tolist([])
  },
])
vm_out = {
  "id" = "c43e9f42-c48d-2dce-19cd-2a2b7ba447ef"
  "name_label" = "Test CentOS VM"
  "other_config" = tomap({
    "flag" = "1"
  })
  "snapshots" = tolist([])
  "template_name" = "CentOS 7"
}
```