### PR TITLE
Implement xenserver vbd provider list attribute

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,3 +1,5 @@
+WORKDIR ?= examples/terraform-main
+
 SHELL := /bin/bash
 default: testacc
 
@@ -16,26 +18,26 @@ provider: go.mod  ## make provider
 	ls -l $(GOBIN)/terraform-provider-xenserver
 
 apply: .env provider  ## make apply
-	cd examples/terraform-main && \
+	cd $(WORKDIR) && \
     terraform plan && \
     terraform apply -auto-approve
 
 show_state: .env  ## make show_state resource=xenserver_vm.vm
-	@cd examples/terraform-main && \
+	@cd $(WORKDIR) && \
 	if [ -z "$(resource)" ]; then echo "USAGE: make show_state resource=<>" && \
 	echo "List available resources:" && echo "`terraform state list`" && exit 1; fi && \
 	terraform state show $(resource)
 
 import: .env  ## make import resource=xenserver_vm.vm id=vm-uuid
-	@cd examples/terraform-main && \
+	@cd $(WORKDIR) && \
 	if [ -z "$(resource)" ] || [ -z "$(id)" ]; then echo "USAGE: make import resource=<> id=<>"; exit 1; fi && \
 	terraform import $(resource) $(id)
 
 remove: .env  ## make remove resource=xenserver_vm.vm
-	@cd examples/terraform-main && \
+	@cd $(WORKDIR) && \
 	if [ -z "$(resource)" ]; then echo "USAGE: make remove resource=<>"; exit 1; fi && \
 	terraform state rm $(resource)
 
 destroy:
-	cd examples/terraform-main && \
+	cd $(WORKDIR) && \
     terraform destroy -auto-approve

--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -31,6 +31,7 @@ output "vm_out" {
 
 ### Required
 
+- `hard_drive` (List of String) A list of vdi uuids to attach to the virtual machine
 - `name_label` (String) The name of the virtual machine
 - `template_name` (String) The template name of the virtual machine which cloned from
 
@@ -41,7 +42,6 @@ output "vm_out" {
 ### Read-Only
 
 - `id` (String) UUID of the virtual machine
-- `snapshots` (List of String) The all snapshots of the virtual machine
 
 ## Import
 

--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -13,12 +13,36 @@ VM resource
 ## Example Usage
 
 ```terraform
+data "xenserver_sr" "sr" {
+  name_label = "Local storage"
+}
+
+resource "xenserver_vdi" "vdi1" {
+  name_label   = "local-storage-vdi-1"
+  sr_uuid      = data.xenserver_sr.sr.data_items[0].uuid
+  virtual_size = 100 * 1024 * 1024 * 1024
+}
+resource "xenserver_vdi" "vdi2" {
+  name_label   = "local-storage-vdi-2"
+  sr_uuid      = data.xenserver_sr.sr.data_items[0].uuid
+  virtual_size = 100 * 1024 * 1024 * 1024
+}
+
 resource "xenserver_vm" "vm" {
-  name_label    = "Test CentOS VM"
-  template_name = "CentOS 7"
-  other_config = {
-    flag = "1"
-  }
+  name_label    = "A test virtual-machine"
+  template_name = "Windows 11"
+  hard_drive = [
+    {
+      vdi_uuid = xenserver_vdi.vdi1.id,
+      bootable = true,
+      mode     = "RW"
+    },
+    {
+      vdi_uuid = xenserver_vdi.vdi2.id,
+      bootable = false,
+      mode     = "RO"
+    },
+  ]
 }
 
 output "vm_out" {
@@ -54,6 +78,10 @@ Optional:
 
 - `bootable` (Boolean) Set VBD as bootable, Default: false
 - `mode` (String) The mode the VBD should be mounted with, Default: RW
+
+Read-Only:
+
+- `vbd_ref` (String) VBD Reference
 
 ## Import
 

--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -31,7 +31,7 @@ output "vm_out" {
 
 ### Required
 
-- `hard_drive` (List of String) A list of vdi uuids to attach to the virtual machine
+- `hard_drive` (Attributes List) A list of hard drive attributes to attach to the virtual machine (see [below for nested schema](#nestedatt--hard_drive))
 - `name_label` (String) The name of the virtual machine
 - `template_name` (String) The template name of the virtual machine which cloned from
 
@@ -42,6 +42,18 @@ output "vm_out" {
 ### Read-Only
 
 - `id` (String) UUID of the virtual machine
+
+<a id="nestedatt--hard_drive"></a>
+### Nested Schema for `hard_drive`
+
+Required:
+
+- `vdi_uuid` (String) VDI UUID to attach to VBD
+
+Optional:
+
+- `bootable` (Boolean) Set VBD as bootable, Default: false
+- `mode` (String) The mode the VBD should be mounted with, Default: RW
 
 ## Import
 

--- a/examples/resources/xenserver_vm/resource.tf
+++ b/examples/resources/xenserver_vm/resource.tf
@@ -1,9 +1,33 @@
+data "xenserver_sr" "sr" {
+  name_label = "Local storage"
+}
+
+resource "xenserver_vdi" "vdi1" {
+  name_label   = "local-storage-vdi-1"
+  sr_uuid      = data.xenserver_sr.sr.data_items[0].uuid
+  virtual_size = 100 * 1024 * 1024 * 1024
+}
+resource "xenserver_vdi" "vdi2" {
+  name_label   = "local-storage-vdi-2"
+  sr_uuid      = data.xenserver_sr.sr.data_items[0].uuid
+  virtual_size = 100 * 1024 * 1024 * 1024
+}
+
 resource "xenserver_vm" "vm" {
-  name_label    = "Test CentOS VM"
-  template_name = "CentOS 7"
-  other_config = {
-    flag = "1"
-  }
+  name_label    = "A test virtual-machine"
+  template_name = "Windows 11"
+  hard_drive = [
+    {
+      vdi_uuid = xenserver_vdi.vdi1.id,
+      bootable = true,
+      mode     = "RW"
+    },
+    {
+      vdi_uuid = xenserver_vdi.vdi2.id,
+      bootable = false,
+      mode     = "RO"
+    },
+  ]
 }
 
 output "vm_out" {

--- a/examples/vm-main/main.tf
+++ b/examples/vm-main/main.tf
@@ -1,0 +1,44 @@
+locals {
+  env_vars = { for tuple in regexall("export\\s*(\\S*)\\s*=\\s*(\\S*)\\s*", file("../../.env")) : tuple[0] => tuple[1] }
+}
+
+terraform {
+  required_providers {
+    xenserver = {
+      source = "xenserver/xenserver"
+    }
+  }
+}
+
+provider "xenserver" {
+  host     = local.env_vars["XENSERVER_HOST"]
+  username = local.env_vars["XENSERVER_USERNAME"]
+  password = local.env_vars["XENSERVER_PASSWORD"]
+}
+
+data "xenserver_sr" "sr" {
+  name_label = "Local storage"
+}
+
+resource "xenserver_vdi" "vdi1" {
+  name_label   = "local-storage-vdi-1"
+  sr_uuid      = data.xenserver_sr.sr.data_items[0].uuid
+  virtual_size = 100 * 1024 * 1024 * 1024
+}
+resource "xenserver_vdi" "vdi2" {
+  name_label   = "local-storage-vdi-2"
+  sr_uuid      = data.xenserver_sr.sr.data_items[0].uuid
+  virtual_size = 100 * 1024 * 1024 * 1024
+}
+
+resource "xenserver_vm" "vm" {
+  name_label    = "A test virtual-machine"
+  template_name = "Windows 11"
+  hard_drive    = [xenserver_vdi.vdi1.id, xenserver_vdi.vdi2.id]
+}
+
+output "vm_out" {
+  value = xenserver_vm.vm
+}
+
+

--- a/examples/vm-main/main.tf
+++ b/examples/vm-main/main.tf
@@ -34,7 +34,18 @@ resource "xenserver_vdi" "vdi2" {
 resource "xenserver_vm" "vm" {
   name_label    = "A test virtual-machine"
   template_name = "Windows 11"
-  hard_drive    = [xenserver_vdi.vdi1.id, xenserver_vdi.vdi2.id]
+  hard_drive = [
+    {
+      vdi_uuid = xenserver_vdi.vdi1.id,
+      bootable = true,
+      mode     = "RW"
+    },
+    {
+      vdi_uuid = xenserver_vdi.vdi2.id,
+      bootable = false,
+      mode     = "RO"
+    },
+  ]
 }
 
 output "vm_out" {

--- a/xenserver/sr_utils.go
+++ b/xenserver/sr_utils.go
@@ -318,16 +318,16 @@ func updateNFSResourceModel(srRecord xenapi.SRRecord, pbdRecord xenapi.PBDRecord
 	data.NameLabel = types.StringValue(srRecord.NameLabel)
 	server, ok := pbdRecord.DeviceConfig["server"]
 	if !ok {
-		return errors.New(`Unable to find "server" in PBD device config`)
+		return errors.New(`unable to find "server" in PBD device config`)
 	}
 	serverPath, ok := pbdRecord.DeviceConfig["serverpath"]
 	if !ok {
-		return errors.New(`Unable to find "serverpath" in PBD device config`)
+		return errors.New(`unable to find "serverpath" in PBD device config`)
 	}
 	data.StorageLocation = types.StringValue(server + ":" + serverPath)
 	nfsVersion, ok := pbdRecord.DeviceConfig["nfsversion"]
 	if !ok {
-		return errors.New(`Unable to find "nfsversion" in PBD device config`)
+		return errors.New(`unable to find "nfsversion" in PBD device config`)
 	}
 	data.Version = types.StringValue(nfsVersion)
 	err := updateNFSResourceModelComputed(srRecord, pbdRecord, data)

--- a/xenserver/vbd_utils.go
+++ b/xenserver/vbd_utils.go
@@ -3,63 +3,108 @@ package xenserver
 import (
 	"context"
 	"errors"
+	"sort"
 	"xenapi"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-func createVBD(vdiUUID string, vmRef xenapi.VMRef, session *xenapi.Session) (xenapi.VBDRef, error) {
-	vdiRef, err := xenapi.VDI.GetByUUID(session, vdiUUID)
+type vbdResourceModel struct {
+	VDI      types.String `tfsdk:"vdi_uuid"`
+	Mode     types.String `tfsdk:"mode"`
+	Bootable types.Bool   `tfsdk:"bootable"`
+}
+
+var vbdResourceModelAttrTypes = map[string]attr.Type{
+	"vdi_uuid": types.StringType,
+	"mode":     types.StringType,
+	"bootable": types.BoolType,
+}
+
+func VBDSchema() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"vdi_uuid": schema.StringAttribute{
+			MarkdownDescription: "VDI UUID to attach to VBD",
+			Required:            true,
+		},
+		"bootable": schema.BoolAttribute{
+			MarkdownDescription: "Set VBD as bootable, Default: false",
+			Optional:            true,
+			Computed:            true,
+			Default:             booldefault.StaticBool(false),
+		},
+		"mode": schema.StringAttribute{
+			MarkdownDescription: "The mode the VBD should be mounted with, Default: RW",
+			Optional:            true,
+			Computed:            true,
+			Default:             stringdefault.StaticString("RW"),
+		},
+	}
+}
+
+func createVBD(vbd vbdResourceModel, vmRef xenapi.VMRef, session *xenapi.Session) (xenapi.VBDRef, error) {
+	var vbdRef xenapi.VBDRef
+	vdiRef, err := xenapi.VDI.GetByUUID(session, vbd.VDI.ValueString())
 	if err != nil {
-		return "", errors.New("unable to get VDI ref, vdi UUID: " + vdiUUID)
+		return vbdRef, errors.New("unable to get VDI ref, vdi UUID: " + vbd.VDI.String())
 	}
 
-	userDevices, _ := xenapi.VM.GetAllowedVBDDevices(session, vmRef)
+	userDevices, err := xenapi.VM.GetAllowedVBDDevices(session, vmRef)
+	if err != nil {
+		return vbdRef, errors.New("unable to get allowed VBD devices for vm " + string(vmRef))
+	}
+
 	if len(userDevices) == 0 {
-		return "", errors.New("No available devices to attach to vm " + string(vmRef))
+		return vbdRef, errors.New("unable to find available devices to attach to vm " + string(vmRef))
 	}
 
 	vbdRecord := xenapi.VBDRecord{
 		VM:         vmRef,
 		VDI:        vdiRef,
 		Type:       "Disk",
-		Mode:       "RW",
-		Bootable:   false,
+		Mode:       xenapi.VbdMode(vbd.Mode.ValueString()),
+		Bootable:   vbd.Bootable.ValueBool(),
 		Empty:      false,
 		Userdevice: userDevices[0],
 	}
 
-	vbdRef, err := xenapi.VBD.Create(session, vbdRecord)
+	vbdRef, err = xenapi.VBD.Create(session, vbdRecord)
 	if err != nil {
-		return "", errors.New("unable to create VBD, vdi UUID: " + vdiUUID)
+		return vbdRef, errors.New("unable to create VBD, vdi UUID: " + vbd.VDI.String())
 	}
 
 	// plug VBDs if VM is running
 	vmPowerState, err := xenapi.VM.GetPowerState(session, vmRef)
 	if err != nil {
-		return "", errors.New("unable to get VM power state, vm ref: " + string(vmRef))
+		return vbdRef, errors.New("unable to get VM power state, vm ref: " + string(vmRef))
 	}
 
 	if vmPowerState == xenapi.VMPowerStateRunning {
 		err = xenapi.VBD.Plug(session, vbdRef)
 		if err != nil {
-			return "", errors.New("unable to plug VBD, vdi UUID: " + vdiUUID)
+			return vbdRef, errors.New("unable to plug VBD, vdi UUID: " + vbd.VDI.String())
 		}
 	}
 
 	return vbdRef, nil
 }
 
-func createVBDs(ctx context.Context, vdiUUIDs types.List, vmRef xenapi.VMRef, session *xenapi.Session) ([]xenapi.VBDRef, error) {
-	elements := make([]string, 0, len(vdiUUIDs.Elements()))
-	diags := vdiUUIDs.ElementsAs(ctx, &elements, false)
+func createVBDs(ctx context.Context, data vmResourceModel, vmRef xenapi.VMRef, session *xenapi.Session) ([]xenapi.VBDRef, error) {
+	elements := make([]vbdResourceModel, 0, len(data.HardDrive.Elements()))
+	diags := data.HardDrive.ElementsAs(ctx, &elements, false)
 	if diags.HasError() {
-		return nil, errors.New("unable to get VDI UUIDs in plan data hard drive attributes")
+		return nil, errors.New("unable to get HardDrive elements")
 	}
 
 	var vbdRefs []xenapi.VBDRef
-	for _, vdiUUID := range elements {
-		vbdRef, err := createVBD(vdiUUID, vmRef, session)
+	for _, vbd := range elements {
+		vbdRef, err := createVBD(vbd, vmRef, session)
 		if err != nil {
 			return nil, err
 		}
@@ -68,25 +113,80 @@ func createVBDs(ctx context.Context, vdiUUIDs types.List, vmRef xenapi.VMRef, se
 	return vbdRefs, nil
 }
 
-func updateVBDs(planVDIUUIDs []string, stateVDIUUIDs []string, vmRef xenapi.VMRef, session *xenapi.Session) error {
+func sortHardDrive(ctx context.Context, unSortedList basetypes.ListValue) (basetypes.ListValue, error) {
+	var listValue basetypes.ListValue
+	vbdList := make([]vbdResourceModel, 0, len(unSortedList.Elements()))
+	diags := unSortedList.ElementsAs(ctx, &vbdList, false)
+	if diags.HasError() {
+		return listValue, errors.New("unable to get VBD list")
+	}
+
+	sort.Slice(vbdList, func(i, j int) bool {
+		return vbdList[i].VDI.ValueString() < vbdList[j].VDI.ValueString()
+	})
+
+	listValue, diags = types.ListValueFrom(ctx, types.ObjectType{AttrTypes: vbdResourceModelAttrTypes}, vbdList)
+	if diags.HasError() {
+		return listValue, errors.New("unable to get VBD list value")
+	}
+
+	return listValue, nil
+}
+
+func updateVBDs(ctx context.Context, plan vmResourceModel, state vmResourceModel, vmRef xenapi.VMRef, session *xenapi.Session) error {
+	// Get VBDs from plan and state
+	planVBDs := make([]vbdResourceModel, 0, len(state.HardDrive.Elements()))
+	diags := plan.HardDrive.ElementsAs(ctx, &planVBDs, false)
+	if diags.HasError() {
+		return errors.New("unable to get VBDs in plan data")
+	}
+
+	stateVBDs := make([]vbdResourceModel, 0, len(state.HardDrive.Elements()))
+	diags = state.HardDrive.ElementsAs(ctx, &stateVBDs, false)
+	if diags.HasError() {
+		return errors.New("unable to get VBDs in state data")
+	}
+
 	var err error
-
-	planVDIsMap := make(map[string]bool, len(planVDIUUIDs))
-	for _, vdiUUID := range planVDIUUIDs {
-		planVDIsMap[vdiUUID] = true
+	planVDIsMap := make(map[string]vbdResourceModel)
+	for _, vbd := range planVBDs {
+		planVDIsMap[vbd.VDI.ValueString()] = vbd
 	}
 
-	stateVDIsMap := make(map[string]bool, len(stateVDIUUIDs))
-	for _, vdiUUID := range stateVDIUUIDs {
-		stateVDIsMap[vdiUUID] = true
+	stateVDIsMap := make(map[string]vbdResourceModel)
+	for _, vbd := range stateVBDs {
+		stateVDIsMap[vbd.VDI.ValueString()] = vbd
 	}
 
-	// Create VBDs that are in plan but not in state
-	for vdiUUID := range planVDIsMap {
-		if _, ok := stateVDIsMap[vdiUUID]; !ok {
-			_, err = createVBD(vdiUUID, vmRef, session)
+	// Create VBDs that are in plan but not in state, Update VBDs if already exists and attributes changed
+	for vdiUUID, vbd := range planVDIsMap {
+		_, ok := stateVDIsMap[vdiUUID]
+		if !ok {
+			tflog.Debug(ctx, "---> Create VBD for VDI: "+vdiUUID+" <---")
+			_, err = createVBD(vbd, vmRef, session)
 			if err != nil {
 				return err
+			}
+		} else {
+			vbdRef, err := getVBDRef(session, vdiUUID, vmRef)
+			if err != nil {
+				return err
+			}
+
+			tflog.Debug(ctx, "---> Update VBD "+string(vbdRef)+" for VDI: "+vdiUUID+" <---")
+
+			if planVDIsMap[vdiUUID].Mode != stateVDIsMap[vdiUUID].Mode {
+				err = xenapi.VBD.SetMode(session, vbdRef, xenapi.VbdMode(planVDIsMap[vdiUUID].Mode.ValueString()))
+				if err != nil {
+					return errors.New(err.Error())
+				}
+			}
+
+			if planVDIsMap[vdiUUID].Bootable != stateVDIsMap[vdiUUID].Bootable {
+				err = xenapi.VBD.SetBootable(session, vbdRef, planVDIsMap[vdiUUID].Bootable.ValueBool())
+				if err != nil {
+					return errors.New(err.Error())
+				}
 			}
 		}
 	}
@@ -94,7 +194,8 @@ func updateVBDs(planVDIUUIDs []string, stateVDIUUIDs []string, vmRef xenapi.VMRe
 	// Destroy VBDs that are not in plan
 	for vdiUUID := range stateVDIsMap {
 		if _, ok := planVDIsMap[vdiUUID]; !ok {
-			err = removeVBDbyVDIUUID(session, vdiUUID)
+			tflog.Debug(ctx, "---> Destroy VBD for VDI: "+vdiUUID+" <---")
+			err = removeVBD(session, vdiUUID, vmRef)
 			if err != nil {
 				return err
 			}
@@ -103,23 +204,42 @@ func updateVBDs(planVDIUUIDs []string, stateVDIUUIDs []string, vmRef xenapi.VMRe
 
 	return nil
 }
+func getVBDRef(session *xenapi.Session, vdiUUID string, vmRef xenapi.VMRef) (xenapi.VBDRef, error) {
+	var vbdRef xenapi.VBDRef
 
-func removeVBDbyVDIUUID(session *xenapi.Session, vdiUUID string) error {
 	VDIRef, err := xenapi.VDI.GetByUUID(session, vdiUUID)
 	if err != nil {
-		return errors.New("unable to get VDI ref, vdi UUID: " + vdiUUID)
+		return vbdRef, errors.New("unable to get VDI ref, vdi UUID: " + vdiUUID)
 	}
 
 	VBDRefs, err := xenapi.VDI.GetVBDs(session, VDIRef)
 	if err != nil {
-		return errors.New("unable to get VBDs for VDI, vdi UUID: " + vdiUUID)
+		return vbdRef, errors.New("unable to get VBDs for VDI, vdi UUID: " + vdiUUID)
 	}
 
 	for _, vbdRef := range VBDRefs {
-		err = xenapi.VBD.Destroy(session, vbdRef)
+		vbdRecord, err := xenapi.VBD.GetRecord(session, vbdRef)
 		if err != nil {
-			return errors.New("unable to destroy VBD, vbd ref: " + string(vbdRef))
+			return vbdRef, errors.New("unable to get VBD record, vbd ref: " + string(vbdRef))
 		}
+
+		if vbdRecord.VM == vmRef {
+			return vbdRef, nil
+		}
+	}
+
+	return vbdRef, nil
+}
+
+func removeVBD(session *xenapi.Session, vdiUUID string, vmRef xenapi.VMRef) error {
+	vbdRef, err := getVBDRef(session, vdiUUID, vmRef)
+	if err != nil {
+		return err
+	}
+
+	err = xenapi.VBD.Destroy(session, vbdRef)
+	if err != nil {
+		return errors.New("unable to destroy VBD, vbd ref: " + string(vbdRef))
 	}
 	return nil
 }

--- a/xenserver/vbd_utils.go
+++ b/xenserver/vbd_utils.go
@@ -1,0 +1,125 @@
+package xenserver
+
+import (
+	"context"
+	"errors"
+	"xenapi"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func createVBD(vdiUUID string, vmRef xenapi.VMRef, session *xenapi.Session) (xenapi.VBDRef, error) {
+	vdiRef, err := xenapi.VDI.GetByUUID(session, vdiUUID)
+	if err != nil {
+		return "", errors.New("unable to get VDI ref, vdi UUID: " + vdiUUID)
+	}
+
+	userDevices, _ := xenapi.VM.GetAllowedVBDDevices(session, vmRef)
+	if len(userDevices) == 0 {
+		return "", errors.New("No available devices to attach to vm " + string(vmRef))
+	}
+
+	vbdRecord := xenapi.VBDRecord{
+		VM:         vmRef,
+		VDI:        vdiRef,
+		Type:       "Disk",
+		Mode:       "RW",
+		Bootable:   false,
+		Empty:      false,
+		Userdevice: userDevices[0],
+	}
+
+	vbdRef, err := xenapi.VBD.Create(session, vbdRecord)
+	if err != nil {
+		return "", errors.New("unable to create VBD, vdi UUID: " + vdiUUID)
+	}
+
+	// plug VBDs if VM is running
+	vmPowerState, err := xenapi.VM.GetPowerState(session, vmRef)
+	if err != nil {
+		return "", errors.New("unable to get VM power state, vm ref: " + string(vmRef))
+	}
+
+	if vmPowerState == xenapi.VMPowerStateRunning {
+		err = xenapi.VBD.Plug(session, vbdRef)
+		if err != nil {
+			return "", errors.New("unable to plug VBD, vdi UUID: " + vdiUUID)
+		}
+	}
+
+	return vbdRef, nil
+}
+
+func createVBDs(ctx context.Context, vdiUUIDs types.List, vmRef xenapi.VMRef, session *xenapi.Session) ([]xenapi.VBDRef, error) {
+	elements := make([]string, 0, len(vdiUUIDs.Elements()))
+	diags := vdiUUIDs.ElementsAs(ctx, &elements, false)
+	if diags.HasError() {
+		return nil, errors.New("unable to get VDI UUIDs in plan data hard drive attributes")
+	}
+
+	var vbdRefs []xenapi.VBDRef
+	for _, vdiUUID := range elements {
+		vbdRef, err := createVBD(vdiUUID, vmRef, session)
+		if err != nil {
+			return nil, err
+		}
+		vbdRefs = append(vbdRefs, vbdRef)
+	}
+	return vbdRefs, nil
+}
+
+func updateVBDs(planVDIUUIDs []string, stateVDIUUIDs []string, vmRef xenapi.VMRef, session *xenapi.Session) error {
+	var err error
+
+	planVDIsMap := make(map[string]bool, len(planVDIUUIDs))
+	for _, vdiUUID := range planVDIUUIDs {
+		planVDIsMap[vdiUUID] = true
+	}
+
+	stateVDIsMap := make(map[string]bool, len(stateVDIUUIDs))
+	for _, vdiUUID := range stateVDIUUIDs {
+		stateVDIsMap[vdiUUID] = true
+	}
+
+	// Create VBDs that are in plan but not in state
+	for vdiUUID := range planVDIsMap {
+		if _, ok := stateVDIsMap[vdiUUID]; !ok {
+			_, err = createVBD(vdiUUID, vmRef, session)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	// Destroy VBDs that are not in plan
+	for vdiUUID := range stateVDIsMap {
+		if _, ok := planVDIsMap[vdiUUID]; !ok {
+			err = removeVBDbyVDIUUID(session, vdiUUID)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func removeVBDbyVDIUUID(session *xenapi.Session, vdiUUID string) error {
+	VDIRef, err := xenapi.VDI.GetByUUID(session, vdiUUID)
+	if err != nil {
+		return errors.New("unable to get VDI ref, vdi UUID: " + vdiUUID)
+	}
+
+	VBDRefs, err := xenapi.VDI.GetVBDs(session, VDIRef)
+	if err != nil {
+		return errors.New("unable to get VBDs for VDI, vdi UUID: " + vdiUUID)
+	}
+
+	for _, vbdRef := range VBDRefs {
+		err = xenapi.VBD.Destroy(session, vbdRef)
+		if err != nil {
+			return errors.New("unable to destroy VBD, vbd ref: " + string(vbdRef))
+		}
+	}
+	return nil
+}

--- a/xenserver/vm_data_source_test.go
+++ b/xenserver/vm_data_source_test.go
@@ -22,7 +22,13 @@ resource "xenserver_vdi" "vdi" {
 resource "xenserver_vm" "test_vm" {
   name_label = "%s"
   template_name = "Windows 11"
-  hard_drive = [ xenserver_vdi.vdi.id ]
+  hard_drive = [ 
+    { 
+      vdi_uuid = xenserver_vdi.vdi.id,
+      bootable = true,
+      mode = "RW"
+    },
+  ]
   other_config = {
   	"flag" = "1"
   }

--- a/xenserver/vm_data_source_test.go
+++ b/xenserver/vm_data_source_test.go
@@ -9,9 +9,23 @@ import (
 
 func testAccVMDataSourceConfig(name_label string) string {
 	return fmt.Sprintf(`
+data "xenserver_sr" "sr" {
+  name_label = "Local storage"
+}
+
+resource "xenserver_vdi" "vdi" {
+  name_label       = "local-storage-vdi"
+  sr_uuid          = data.xenserver_sr.sr.data_items[0].uuid
+  virtual_size     = 100 * 1024 * 1024 * 1024
+}
+
 resource "xenserver_vm" "test_vm" {
-	name_label = "%s"
-	template_name = "CentOS 7"
+  name_label = "%s"
+  template_name = "Windows 11"
+  hard_drive = [ xenserver_vdi.vdi.id ]
+  other_config = {
+  	"flag" = "1"
+  }
 }
 
 data "xenserver_vm" "test_vm_data" {

--- a/xenserver/vm_resouce.go
+++ b/xenserver/vm_resouce.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"xenapi"
@@ -127,7 +126,14 @@ func (r *vmResource) Create(ctx context.Context, req resource.CreateRequest, res
 		return
 	}
 
-	plan.UUID = types.StringValue(vmRecord.UUID)
+	err = updateVMResourceModelComputed(ctx, r.session, vmRecord, &plan)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to update VM resource model state",
+			err.Error(),
+		)
+		return
+	}
 
 	plan.HardDrive, err = sortHardDrive(ctx, plan.HardDrive)
 	if err != nil {

--- a/xenserver/vm_resource_test.go
+++ b/xenserver/vm_resource_test.go
@@ -22,7 +22,13 @@ resource "xenserver_vdi" "vdi" {
 resource "xenserver_vm" "test_vm" {
   name_label = "%s"
   template_name = "Windows 11"
-  hard_drive = [ xenserver_vdi.vdi.id ]
+  hard_drive = [
+    { 
+      vdi_uuid = xenserver_vdi.vdi.id,
+      bootable = true,
+      mode = "RW"
+    },
+  ]
   other_config = {
   	"flag" = "1"
   }

--- a/xenserver/vm_resource_test.go
+++ b/xenserver/vm_resource_test.go
@@ -47,6 +47,10 @@ func TestAccVMResource(t *testing.T) {
 					resource.TestCheckResourceAttr("xenserver_vm.test_vm", "name_label", "test vm 1"),
 					resource.TestCheckResourceAttr("xenserver_vm.test_vm", "template_name", "Windows 11"),
 					resource.TestCheckResourceAttr("xenserver_vm.test_vm", "hard_drive.#", "1"),
+					resource.TestCheckResourceAttr("xenserver_vm.test_vm", "hard_drive.0.%", "4"),
+					resource.TestCheckResourceAttr("xenserver_vm.test_vm", "hard_drive.0.mode", "RW"),
+					resource.TestCheckResourceAttr("xenserver_vm.test_vm", "hard_drive.0.bootable", "true"),
+					resource.TestCheckResourceAttrSet("xenserver_vm.test_vm", "hard_drive.0.vbd_ref"),
 					resource.TestCheckResourceAttr("xenserver_vm.test_vm", "other_config.%", "1"),
 					resource.TestCheckResourceAttr("xenserver_vm.test_vm", "other_config.flag", "1"),
 					// Verify dynamic values have any value set in the state.

--- a/xenserver/vm_utils.go
+++ b/xenserver/vm_utils.go
@@ -369,6 +369,7 @@ func getVMOtherConfig(ctx context.Context, data vmResourceModel) (map[string]str
 
 func updateVMResourceModelComputed(ctx context.Context, session *xenapi.Session, vmRecord xenapi.VMRecord, data *vmResourceModel) error {
 	var err error
+	data.UUID = types.StringValue(vmRecord.UUID)
 	data.HardDrive, err = getVBDsFromVMRecord(ctx, session, vmRecord)
 	if err != nil {
 		return err
@@ -389,11 +390,7 @@ func updateVMResourceModel(ctx context.Context, session *xenapi.Session, vmRecor
 		return errors.New("unable to read VM other config")
 	}
 
-	err := updateVMResourceModelComputed(ctx, session, vmRecord, data)
-	if err != nil {
-		return err
-	}
-	return nil
+	return updateVMResourceModelComputed(ctx, session, vmRecord, data)
 }
 
 func getVBDsFromVMRecord(ctx context.Context, session *xenapi.Session, vmRecord xenapi.VMRecord) (basetypes.ListValue, error) {
@@ -414,6 +411,7 @@ func getVBDsFromVMRecord(ctx context.Context, session *xenapi.Session, vmRecord 
 			VDI:      types.StringValue(vdiRecord.UUID),
 			Bootable: types.BoolValue(vbdRecord.Bootable),
 			Mode:     types.StringValue(string(vbdRecord.Mode)),
+			VBD:      types.StringValue(string(vbdRef)),
 		}
 
 		vbdList = append(vbdList, vbd)


### PR DESCRIPTION
```
$make testacc
if [ -z "/home/feis/.local/go/bin" ]; then echo "GOBIN is not set" && exit 1; fi
go mod tidy
go install .
ls -l /home/feis/.local/go/bin/terraform-provider-xenserver
-rwxrwxr-x 1 feis feis 22730403 Jul  2 16:10 /home/feis/.local/go/bin/terraform-provider-xenserver
source .env && TF_ACC=1 go test ./xenserver/ -v   -timeout 120m
=== RUN   TestAccNetworkResource
--- PASS: TestAccNetworkResource (1.82s)
=== RUN   TestAccPifDataSource
--- PASS: TestAccPifDataSource (0.76s)
=== RUN   TestAccSRDataSource
--- PASS: TestAccSRDataSource (0.77s)
=== RUN   TestAccNFSResource
--- PASS: TestAccNFSResource (9.05s)
=== RUN   TestAccSRResourceLocal
--- PASS: TestAccSRResourceLocal (3.53s)
=== RUN   TestAccSRResourceShared
--- PASS: TestAccSRResourceShared (8.30s)
=== RUN   TestAccVDIResource
--- PASS: TestAccVDIResource (3.49s)
=== RUN   TestAccVMDataSource
--- PASS: TestAccVMDataSource (2.29s)
=== RUN   TestAccVMResource
--- PASS: TestAccVMResource (3.21s)
PASS
ok      terraform-provider-xenserver/xenserver  33.232s
```

```
Terraform will perform the following actions:

  # xenserver_vm.vm will be updated in-place
  ~ resource "xenserver_vm" "vm" {
      ~ hard_drive    = [
            "0119b54e-8305-4f01-9bbc-c6e19d7f1539",
          + "96c23cce-75d7-4593-9cbd-1fdd60e0bfb0",
        ]
        id            = "edcefc7a-ca80-1218-ab43-e045cd031cb2"
        # (3 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  ~ vm_out = {
      ~ hard_drive    = [
            "0119b54e-8305-4f01-9bbc-c6e19d7f1539",
          + "96c23cce-75d7-4593-9cbd-1fdd60e0bfb0",
        ]
        id            = "edcefc7a-ca80-1218-ab43-e045cd031cb2"
        # (3 unchanged attributes hidden)
    }
xenserver_vm.vm: Modifying... [id=edcefc7a-ca80-1218-ab43-e045cd031cb2]
xenserver_vm.vm: Modifications complete after 0s [id=edcefc7a-ca80-1218-ab43-e045cd031cb2]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

Outputs:

vm_out = {
  "hard_drive" = tolist([
    "0119b54e-8305-4f01-9bbc-c6e19d7f1539",
    "96c23cce-75d7-4593-9cbd-1fdd60e0bfb0",
  ])
  "id" = "edcefc7a-ca80-1218-ab43-e045cd031cb2"
  "name_label" = "A test virtual-machine"
  "other_config" = tomap({})
  "template_name" = "Windows 11"
}
```
