### PR TITLE
CA-395464: add resource cleanup function (except for VM resource)

### DIFF
--- a/examples/terraform-main/main.tf
+++ b/examples/terraform-main/main.tf
@@ -127,5 +127,5 @@ resource "xenserver_network_vlan" "vlan" {
 }
 
 output "vlan_output" {
-  value = data.xenserver_network_vlan.vlan
+  value = xenserver_network_vlan.vlan
 }

--- a/xenserver/network_vlan_resource.go
+++ b/xenserver/network_vlan_resource.go
@@ -145,6 +145,13 @@ func (r *vlanResource) Create(ctx context.Context, req resource.CreateRequest, r
 			"Unable to get network record",
 			err.Error(),
 		)
+		err = cleanupVlanResource(r.session, networkRef)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error cleaning up network resource",
+				err.Error(),
+			)
+		}
 		return
 	}
 	err = updateVlanResourceModelComputed(ctx, networkRecord, &data)
@@ -153,6 +160,13 @@ func (r *vlanResource) Create(ctx context.Context, req resource.CreateRequest, r
 			"Unable to update the computed fields of vlanResourceModel",
 			err.Error(),
 		)
+		err = cleanupVlanResource(r.session, networkRef)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error cleaning up network resource",
+				err.Error(),
+			)
+		}
 		return
 	}
 
@@ -163,6 +177,13 @@ func (r *vlanResource) Create(ctx context.Context, req resource.CreateRequest, r
 			"Unable to get vlan create params",
 			err.Error(),
 		)
+		err = cleanupVlanResource(r.session, networkRef)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error cleaning up network resource",
+				err.Error(),
+			)
+		}
 		return
 	}
 	_, err = xenapi.Pool.CreateVLANFromPIF(r.session, params.PifRef, params.NetworkRef, params.Tag)
@@ -171,6 +192,13 @@ func (r *vlanResource) Create(ctx context.Context, req resource.CreateRequest, r
 			"Unable to create vlan",
 			err.Error(),
 		)
+		err = cleanupVlanResource(r.session, networkRef)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error cleaning up network resource",
+				err.Error(),
+			)
+		}
 		return
 	}
 
@@ -288,36 +316,10 @@ func (r *vlanResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		)
 		return
 	}
-	networkRecord, err := xenapi.Network.GetRecord(r.session, networkRef)
+	err = cleanupVlanResource(r.session, networkRef)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Unable to get network record",
-			err.Error(),
-		)
-		return
-	}
-	for _, pifRef := range networkRecord.PIFs {
-		pifRecord, err := xenapi.PIF.GetRecord(r.session, pifRef)
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"Unable to get PIF record",
-				err.Error(),
-			)
-			return
-		}
-		err = xenapi.VLAN.Destroy(r.session, pifRecord.VLANMasterOf)
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"Unable to destroy vlan",
-				err.Error(),
-			)
-			return
-		}
-	}
-	err = xenapi.Network.Destroy(r.session, networkRef)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to destroy network",
+			"Unable to delete network resource",
 			err.Error(),
 		)
 		return

--- a/xenserver/sr_utils.go
+++ b/xenserver/sr_utils.go
@@ -255,13 +255,8 @@ func srResourceModelUpdate(ctx context.Context, session *xenapi.Session, ref xen
 	return nil
 }
 
-func srDelete(session *xenapi.Session, srUUID string) error {
-	// unplug all PBDs on SR before destroying the SR
-	srRef, err := xenapi.SR.GetByUUID(session, srUUID)
-	if err != nil {
-		return errors.New(err.Error())
-	}
-	pbdRefs, err := xenapi.SR.GetPBDs(session, srRef)
+func cleanupSRResource(session *xenapi.Session, ref xenapi.SRRef) error {
+	pbdRefs, err := xenapi.SR.GetPBDs(session, ref)
 	if err != nil {
 		return errors.New(err.Error())
 	}
@@ -277,7 +272,7 @@ func srDelete(session *xenapi.Session, srUUID string) error {
 			}
 		}
 	}
-	err = xenapi.SR.Destroy(session, srRef)
+	err = xenapi.SR.Destroy(session, ref)
 	if err != nil {
 		return errors.New(err.Error())
 	}

--- a/xenserver/vdi_resource.go
+++ b/xenserver/vdi_resource.go
@@ -151,6 +151,13 @@ func (r *vdiResource) Create(ctx context.Context, req resource.CreateRequest, re
 			"Unable to get VDI record",
 			err.Error(),
 		)
+		err = cleanupVDIResource(r.session, vdiRef)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error cleaning up VDI resource",
+				err.Error(),
+			)
+		}
 		return
 	}
 	err = updateVDIResourceModelComputed(ctx, vdiRecord, &data)
@@ -159,6 +166,13 @@ func (r *vdiResource) Create(ctx context.Context, req resource.CreateRequest, re
 			"Unable to update the computed fields of VDIResourceModel",
 			err.Error(),
 		)
+		err = cleanupVDIResource(r.session, vdiRef)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error cleaning up VDI resource",
+				err.Error(),
+			)
+		}
 		return
 	}
 	tflog.Debug(ctx, "VDI created")
@@ -275,10 +289,10 @@ func (r *vdiResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 		)
 		return
 	}
-	err = xenapi.VDI.Destroy(r.session, vdiRef)
+	err = cleanupVDIResource(r.session, vdiRef)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Unable to destroy VDI",
+			"Unable to delete VDI resource",
 			err.Error(),
 		)
 		return

--- a/xenserver/vdi_utils.go
+++ b/xenserver/vdi_utils.go
@@ -112,3 +112,11 @@ func vdiResourceModelUpdate(ctx context.Context, session *xenapi.Session, ref xe
 	}
 	return nil
 }
+
+func cleanupVDIResource(session *xenapi.Session, ref xenapi.VDIRef) error {
+	err := xenapi.VDI.Destroy(session, ref)
+	if err != nil {
+		return errors.New(err.Error())
+	}
+	return nil
+}


### PR DESCRIPTION
test result:
```
ubuntu@ubuntu-server:~/code/terraform-provider-xenserver$ make testacc
if [ -z "/home/ubuntu/go/bin" ]; then echo "GOBIN is not set" && exit 1; fi
go mod tidy
go install .
ls -l /home/ubuntu/go/bin/terraform-provider-xenserver
-rwxrwxr-x 1 ubuntu ubuntu 22905205 Jul  9 08:11 /home/ubuntu/go/bin/terraform-provider-xenserver
source .env && TF_ACC=1 go test ./xenserver/ -v   -timeout 120m
=== RUN   TestAccNetworkDataSource
--- PASS: TestAccNetworkDataSource (0.72s)
=== RUN   TestAccVlanResource
--- PASS: TestAccVlanResource (3.90s)
=== RUN   TestAccNICDataSource
--- PASS: TestAccNICDataSource (0.66s)
=== RUN   TestAccPifDataSource
--- PASS: TestAccPifDataSource (0.67s)
=== RUN   TestAccSnapshotResource
--- PASS: TestAccSnapshotResource (7.49s)
=== RUN   TestAccSRDataSource
--- PASS: TestAccSRDataSource (0.67s)
=== RUN   TestAccNFSResource
--- PASS: TestAccNFSResource (4.47s)
=== RUN   TestAccSRResourceLocal
--- PASS: TestAccSRResourceLocal (3.44s)
=== RUN   TestAccSRResourceShared
--- PASS: TestAccSRResourceShared (4.56s)
=== RUN   TestAccVDIResource
--- PASS: TestAccVDIResource (8.02s)
=== RUN   TestAccVMDataSource
--- PASS: TestAccVMDataSource (2.91s)
=== RUN   TestAccVMResource
--- PASS: TestAccVMResource (3.44s)
PASS
ok      terraform-provider-xenserver/xenserver  40.961s
```  