### PR TITLE
CP-50255: Update VM data source to show only VM list (not include snapshot and template)

### DIFF
--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -31,8 +31,11 @@ resource "xenserver_vdi" "vdi2" {
 data "xenserver_network" "network" {}
 
 resource "xenserver_vm" "vm" {
-  name_label    = "A test virtual-machine"
-  template_name = "Windows 11"
+  name_label       = "A test virtual-machine"
+  template_name    = "Windows 11"
+  static_mem_max   = 4 * 1024 * 1024 * 1024
+  vcpus            = 4
+  cores_per_socket = 2
 
   hard_drive = [
     {
@@ -80,12 +83,18 @@ output "vm_out" {
 
 - `name_label` (String) The name of the virtual machine
 - `network_interface` (Attributes Set) A set of network interface attributes to attach to the virtual machine (see [below for nested schema](#nestedatt--network_interface))
+- `static_mem_max` (Number) Statically-set (i.e. absolute) maximum memory (bytes). This value acts as a hard limit of the amount of memory a guest can use at VM start time. New values only take effect on reboot.
 - `template_name` (String) The template name of the virtual machine which cloned from
+- `vcpus` (Number) The number of VCPUs for the virtual machine
 
 ### Optional
 
+- `cores_per_socket` (Number) The number of core pre socket for the virtual machine
+- `dynamic_mem_max` (Number) Dynamic maximum memory (bytes).
+- `dynamic_mem_min` (Number) Dynamic minimum memory (bytes).
 - `hard_drive` (Attributes Set) A set of hard drive attributes to attach to the virtual machine (see [below for nested schema](#nestedatt--hard_drive))
 - `other_config` (Map of String) The other config of the virtual machine
+- `static_mem_min` (Number) Statically-set (i.e. absolute) mininum memory (bytes). The least amount of memory this VM can boot with without crashing.
 
 ### Read-Only
 

--- a/examples/resources/xenserver_vm/resource.tf
+++ b/examples/resources/xenserver_vm/resource.tf
@@ -16,8 +16,11 @@ resource "xenserver_vdi" "vdi2" {
 data "xenserver_network" "network" {}
 
 resource "xenserver_vm" "vm" {
-  name_label    = "A test virtual-machine"
-  template_name = "Windows 11"
+  name_label       = "A test virtual-machine"
+  template_name    = "Windows 11"
+  static_mem_max   = 4 * 1024 * 1024 * 1024
+  vcpus            = 4
+  cores_per_socket = 2
 
   hard_drive = [
     {

--- a/examples/vm-main/main.tf
+++ b/examples/vm-main/main.tf
@@ -34,8 +34,11 @@ resource "xenserver_vdi" "vdi2" {
 data "xenserver_network" "network" {}
 
 resource "xenserver_vm" "vm" {
-  name_label    = "A test virtual-machine"
-  template_name = "Windows 11"
+  name_label       = "A test virtual-machine"
+  template_name    = "Windows 11"
+  static_mem_max   = 4 * 1024 * 1024 * 1024
+  vcpus            = 4
+  cores_per_socket = 2
 
   hard_drive = [
     {

--- a/xenserver/snapshot_resource_test.go
+++ b/xenserver/snapshot_resource_test.go
@@ -22,8 +22,10 @@ resource "xenserver_vdi" "vdi1" {
 data "xenserver_network" "network" {}
 
 resource "xenserver_vm" "vm" {
-	name_label    = "A test virtual-machine"
-	template_name = "Windows 11"
+	name_label     = "A test virtual-machine"
+	template_name  = "Windows 11"
+	static_mem_max = 4 * 1024 * 1024 * 1024
+	vcpus          = 2
 	hard_drive = [
 		{
 		vdi_uuid = xenserver_vdi.vdi1.uuid,

--- a/xenserver/vm_data_source.go
+++ b/xenserver/vm_data_source.go
@@ -494,6 +494,14 @@ func (d *vmDataSource) Read(ctx context.Context, req datasource.ReadRequest, res
 			continue
 		}
 
+		if vmRecord.IsATemplate || vmRecord.IsDefaultTemplate {
+			continue
+		}
+
+		if vmRecord.SnapshotOf != "OpaqueRef:NULL" {
+			continue
+		}
+
 		var vmItem vmRecordData
 		err := updateVMRecordData(ctx, vmRecord, &vmItem)
 		if err != nil {

--- a/xenserver/vm_data_source_test.go
+++ b/xenserver/vm_data_source_test.go
@@ -22,8 +22,10 @@ resource "xenserver_vdi" "vdi" {
 data "xenserver_network" "network" {}
 
 resource "xenserver_vm" "test_vm" {
-  name_label = "%s"
-  template_name = "Windows 11"
+  name_label     = "%s"
+  template_name  = "Windows 11"
+  static_mem_max = 4 * 1024 * 1024 * 1024
+  vcpus          = 2
   hard_drive = [ 
     { 
       vdi_uuid = xenserver_vdi.vdi.id,

--- a/xenserver/vm_resouce.go
+++ b/xenserver/vm_resouce.go
@@ -119,6 +119,26 @@ func (r *vmResource) Create(ctx context.Context, req resource.CreateRequest, res
 		return
 	}
 
+	// Set memory
+	err = updateVMMemory(r.session, vmRef, plan)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to set VM memory",
+			err.Error(),
+		)
+		return
+	}
+
+	// Set VCPUs
+	err = updateVMCPUs(r.session, vmRef, plan)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to set VM VCPUs",
+			err.Error(),
+		)
+		return
+	}
+
 	// Overwrite data with refreshed resource state
 	vmRecord, err := xenapi.VM.GetRecord(r.session, vmRef)
 	if err != nil {

--- a/xenserver/vm_utils.go
+++ b/xenserver/vm_utils.go
@@ -3,12 +3,15 @@ package xenserver
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -123,6 +126,12 @@ type vmRecordData struct {
 type vmResourceModel struct {
 	NameLabel        types.String `tfsdk:"name_label"`
 	TemplateName     types.String `tfsdk:"template_name"`
+	StaticMemMin     types.Int64  `tfsdk:"static_mem_min"`
+	StaticMemMax     types.Int64  `tfsdk:"static_mem_max"`
+	DynamicMemMin    types.Int64  `tfsdk:"dynamic_mem_min"`
+	DynamicMemMax    types.Int64  `tfsdk:"dynamic_mem_max"`
+	VCPUs            types.Int32  `tfsdk:"vcpus"`
+	CorePerSocket    types.Int32  `tfsdk:"cores_per_socket"`
 	OtherConfig      types.Map    `tfsdk:"other_config"`
 	HardDrive        types.Set    `tfsdk:"hard_drive"`
 	NetworkInterface types.Set    `tfsdk:"network_interface"`
@@ -139,6 +148,35 @@ func VMSchema() map[string]schema.Attribute {
 		"template_name": schema.StringAttribute{
 			MarkdownDescription: "The template name of the virtual machine which cloned from",
 			Required:            true,
+		},
+		"static_mem_min": schema.Int64Attribute{
+			MarkdownDescription: "Statically-set (i.e. absolute) mininum memory (bytes). The least amount of memory this VM can boot with without crashing.",
+			Optional:            true,
+			Computed:            true,
+		},
+		"static_mem_max": schema.Int64Attribute{
+			MarkdownDescription: "Statically-set (i.e. absolute) maximum memory (bytes). This value acts as a hard limit of the amount of memory a guest can use at VM start time. New values only take effect on reboot.",
+			Required:            true,
+		},
+		"dynamic_mem_min": schema.Int64Attribute{
+			MarkdownDescription: "Dynamic minimum memory (bytes).",
+			Optional:            true,
+			Computed:            true,
+		},
+		"dynamic_mem_max": schema.Int64Attribute{
+			MarkdownDescription: "Dynamic maximum memory (bytes).",
+			Optional:            true,
+			Computed:            true,
+		},
+		"vcpus": schema.Int32Attribute{
+			MarkdownDescription: "The number of VCPUs for the virtual machine",
+			Required:            true,
+		},
+		"cores_per_socket": schema.Int32Attribute{
+			MarkdownDescription: "The number of core pre socket for the virtual machine",
+			Optional:            true,
+			Computed:            true,
+			Default:             int32default.StaticInt32(1),
 		},
 		"hard_drive": schema.SetNestedAttribute{
 			MarkdownDescription: "A set of hard drive attributes to attach to the virtual machine",
@@ -424,6 +462,9 @@ func updateVMResourceModelComputed(ctx context.Context, session *xenapi.Session,
 	var err error
 	data.UUID = types.StringValue(vmRecord.UUID)
 	data.ID = types.StringValue(vmRecord.UUID)
+	data.StaticMemMin = types.Int64Value(int64(vmRecord.MemoryStaticMin))
+	data.DynamicMemMin = types.Int64Value(int64(vmRecord.MemoryDynamicMin))
+	data.DynamicMemMax = types.Int64Value(int64(vmRecord.MemoryDynamicMax))
 	data.HardDrive, err = getVBDsFromVMRecord(ctx, session, vmRecord)
 	if err != nil {
 		return err
@@ -447,6 +488,18 @@ func updateVMResourceModelComputed(ctx context.Context, session *xenapi.Session,
 func updateVMResourceModel(ctx context.Context, session *xenapi.Session, vmRecord xenapi.VMRecord, data *vmResourceModel) error {
 	data.NameLabel = types.StringValue(vmRecord.NameLabel)
 	data.TemplateName = types.StringValue(vmRecord.OtherConfig["tf_template_name"])
+	data.StaticMemMax = types.Int64Value(int64(vmRecord.MemoryStaticMax))
+	data.VCPUs = types.Int32Value(int32(vmRecord.VCPUsMax))
+	socket, ok := vmRecord.Platform["cores-per-socket"]
+	if !ok {
+		return errors.New("unable to read VM platform cores-per-socket")
+	}
+	socketInt, err := strconv.Atoi(socket)
+	if err != nil {
+		return errors.New("unable to convert cores-per-socket to an int value")
+	}
+	data.CorePerSocket = types.Int32Value(int32(socketInt)) // #nosec G109
+
 	return updateVMResourceModelComputed(ctx, session, vmRecord, data)
 }
 
@@ -542,6 +595,74 @@ func getVIFsFromVMRecord(ctx context.Context, session *xenapi.Session, vmRecord 
 	return setValue, nil
 }
 
+func updateVMMemory(session *xenapi.Session, vmRef xenapi.VMRef, data vmResourceModel) error {
+	staticMemMax := int(data.StaticMemMax.ValueInt64())
+	staticMemMin := staticMemMax
+	dynamicMemMin := staticMemMax
+	dynamicMemMax := staticMemMax
+	if !data.StaticMemMin.IsUnknown() {
+		staticMemMin = int(data.StaticMemMin.ValueInt64())
+	}
+	if !data.DynamicMemMin.IsUnknown() {
+		dynamicMemMin = int(data.DynamicMemMin.ValueInt64())
+	}
+	if !data.DynamicMemMax.IsUnknown() {
+		dynamicMemMax = int(data.DynamicMemMax.ValueInt64())
+	}
+	err := xenapi.VM.SetMemoryLimits(session, vmRef, staticMemMin, staticMemMax, dynamicMemMin, dynamicMemMax)
+	if err != nil {
+		return errors.New(err.Error())
+	}
+
+	return nil
+}
+
+func updateVMCPUs(session *xenapi.Session, vmRef xenapi.VMRef, data vmResourceModel) error {
+	originVCPUsMax, err := xenapi.VM.GetVCPUsMax(session, vmRef)
+	if err != nil {
+		return errors.New(err.Error())
+	}
+	vcpus := int(data.VCPUs.ValueInt32())
+	// VCPU values must satisfy: 0 < VCPUs_at_startup ≤ VCPUs_max
+	if vcpus < originVCPUsMax {
+		err = xenapi.VM.SetVCPUsAtStartup(session, vmRef, vcpus)
+		if err != nil {
+			return errors.New(err.Error())
+		}
+		err := xenapi.VM.SetVCPUsMax(session, vmRef, vcpus)
+		if err != nil {
+			return errors.New(err.Error())
+		}
+	} else {
+		err := xenapi.VM.SetVCPUsMax(session, vmRef, vcpus)
+		if err != nil {
+			return errors.New(err.Error())
+		}
+		err = xenapi.VM.SetVCPUsAtStartup(session, vmRef, vcpus)
+		if err != nil {
+			return errors.New(err.Error())
+		}
+	}
+	coresPerSocket := int(data.CorePerSocket.ValueInt32())
+	if vcpus%coresPerSocket != 0 {
+		return fmt.Errorf("%d cores could not fit to %d cores-per-socket topology", vcpus, coresPerSocket)
+	}
+	platform, err := xenapi.VM.GetPlatform(session, vmRef)
+	if err != nil {
+		return errors.New(err.Error())
+	}
+	if platform == nil {
+		platform = make(map[string]string)
+	}
+	platform["cores-per-socket"] = strconv.Itoa(coresPerSocket)
+	err = xenapi.VM.SetPlatform(session, vmRef, platform)
+	if err != nil {
+		return errors.New(err.Error())
+	}
+
+	return nil
+}
+
 func vmResourceModelUpdate(ctx context.Context, session *xenapi.Session, vmRef xenapi.VMRef, plan vmResourceModel, state vmResourceModel) error {
 	err := xenapi.VM.SetNameLabel(session, vmRef, plan.NameLabel.ValueString())
 	if err != nil {
@@ -559,6 +680,16 @@ func vmResourceModelUpdate(ctx context.Context, session *xenapi.Session, vmRef x
 	}
 
 	err = updateVIFs(ctx, plan, state, vmRef, session)
+	if err != nil {
+		return err
+	}
+
+	err = updateVMMemory(session, vmRef, plan)
+	if err != nil {
+		return err
+	}
+
+	err = updateVMCPUs(session, vmRef, plan)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
test result:
```
ubuntu@ubuntu-server:~/code/terraform-provider-xenserver$ make testacc
if [ -z "/home/ubuntu/go/bin" ]; then echo "GOBIN is not set" && exit 1; fi
go mod tidy
go: downloading github.com/hashicorp/terraform-plugin-testing v1.9.0
go: downloading github.com/hashicorp/hcl/v2 v2.21.0
go: downloading golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d
go: downloading github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940
go install .
ls -l /home/ubuntu/go/bin/terraform-provider-xenserver
-rwxrwxr-x 1 ubuntu ubuntu 23135597 Jul 17 09:48 /home/ubuntu/go/bin/terraform-provider-xenserver
source .env && TF_ACC=1 go test ./xenserver/ -v   -timeout 120m
=== RUN   TestAccNetworkDataSource
--- PASS: TestAccNetworkDataSource (1.04s)
=== RUN   TestAccVlanResource
--- PASS: TestAccVlanResource (2.97s)
=== RUN   TestAccNICDataSource
--- PASS: TestAccNICDataSource (0.92s)
=== RUN   TestAccPifDataSource
--- PASS: TestAccPifDataSource (0.71s)
=== RUN   TestAccSnapshotResource
--- PASS: TestAccSnapshotResource (6.90s)
=== RUN   TestAccSRDataSource
--- PASS: TestAccSRDataSource (0.71s)
=== RUN   TestAccNFSResource
--- PASS: TestAccNFSResource (4.88s)
=== RUN   TestAccSRResourceLocal
--- PASS: TestAccSRResourceLocal (4.03s)
=== RUN   TestAccSRResourceShared
--- PASS: TestAccSRResourceShared (4.88s)
=== RUN   TestAccVDIResource
--- PASS: TestAccVDIResource (5.86s)
=== RUN   TestAccVMDataSource
--- PASS: TestAccVMDataSource (2.77s)
=== RUN   TestAccVMResource
--- PASS: TestAccVMResource (4.28s)
PASS
ok      terraform-provider-xenserver/xenserver  39.937s
``` 