### PR TITLE
CP-49383: Remove dom0 from return of vm data source and use template default value for cores-per-socket

### DIFF
--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -89,12 +89,12 @@ output "vm_out" {
 
 ### Optional
 
-- `cores_per_socket` (Number) The number of core pre socket for the virtual machine
+- `cores_per_socket` (Number) The number of core pre socket for the virtual machine, default inherited from the template
 - `dynamic_mem_max` (Number) Dynamic maximum memory (bytes).
 - `dynamic_mem_min` (Number) Dynamic minimum memory (bytes).
 - `hard_drive` (Attributes Set) A set of hard drive attributes to attach to the virtual machine (see [below for nested schema](#nestedatt--hard_drive))
 - `other_config` (Map of String) The other config of the virtual machine
-- `static_mem_min` (Number) Statically-set (i.e. absolute) mininum memory (bytes). The least amount of memory this VM can boot with without crashing.
+- `static_mem_min` (Number) Statically-set (i.e. absolute) minimum memory (bytes). The least amount of memory this VM can boot with without crashing.
 
 ### Read-Only
 

--- a/xenserver/vm_data_source.go
+++ b/xenserver/vm_data_source.go
@@ -494,11 +494,7 @@ func (d *vmDataSource) Read(ctx context.Context, req datasource.ReadRequest, res
 			continue
 		}
 
-		if vmRecord.IsATemplate || vmRecord.IsDefaultTemplate {
-			continue
-		}
-
-		if vmRecord.SnapshotOf != "OpaqueRef:NULL" {
+		if vmRecord.IsATemplate || vmRecord.IsDefaultTemplate || vmRecord.SnapshotOf != "OpaqueRef:NULL" || vmRecord.Domid == 0 {
 			continue
 		}
 


### PR DESCRIPTION
test result:
```
ubuntu@ubuntu-server:~/code/terraform-provider-xenserver$ make testacc
if [ -z "/home/ubuntu/go/bin" ]; then echo "GOBIN is not set" && exit 1; fi
go mod tidy
go install .
ls -l /home/ubuntu/go/bin/terraform-provider-xenserver
-rwxrwxr-x 1 ubuntu ubuntu 23160654 Jul 22 05:51 /home/ubuntu/go/bin/terraform-provider-xenserver
source .env && TF_ACC=1 go test ./xenserver/ -v   -timeout 120m
=== RUN   TestAccNetworkDataSource
--- PASS: TestAccNetworkDataSource (0.88s)
=== RUN   TestAccVlanResource
--- PASS: TestAccVlanResource (2.83s)
=== RUN   TestAccNICDataSource
--- PASS: TestAccNICDataSource (0.65s)
=== RUN   TestAccPifDataSource
--- PASS: TestAccPifDataSource (0.65s)
=== RUN   TestAccSnapshotResource
--- PASS: TestAccSnapshotResource (7.05s)
=== RUN   TestAccSRDataSource
--- PASS: TestAccSRDataSource (0.66s)
=== RUN   TestAccNFSResource
--- PASS: TestAccNFSResource (4.77s)
=== RUN   TestAccSRResourceLocal
--- PASS: TestAccSRResourceLocal (3.96s)
=== RUN   TestAccSRResourceShared
--- PASS: TestAccSRResourceShared (4.81s)
=== RUN   TestAccVDIResource
--- PASS: TestAccVDIResource (5.70s)
=== RUN   TestAccVMDataSource
--- PASS: TestAccVMDataSource (2.79s)
=== RUN   TestAccVMResource
--- PASS: TestAccVMResource (4.61s)
PASS
ok      terraform-provider-xenserver/xenserver  39.371s
``` 