### PR TITLE
CP-49383: fix snapshot clean function

### DIFF
--- a/examples/vm-main/main.tf
+++ b/examples/vm-main/main.tf
@@ -23,12 +23,12 @@ data "xenserver_sr" "sr" {
 resource "xenserver_vdi" "vdi1" {
   name_label   = "local-storage-vdi-1"
   sr_uuid      = data.xenserver_sr.sr.data_items[0].uuid
-  virtual_size = 100 * 1024 * 1024 * 1024
+  virtual_size = 10 * 1024 * 1024 * 1024
 }
 resource "xenserver_vdi" "vdi2" {
   name_label   = "local-storage-vdi-2"
   sr_uuid      = data.xenserver_sr.sr.data_items[0].uuid
-  virtual_size = 100 * 1024 * 1024 * 1024
+  virtual_size = 10 * 1024 * 1024 * 1024
 }
 
 data "xenserver_network" "network" {}

--- a/xenserver/snapshot_utils.go
+++ b/xenserver/snapshot_utils.go
@@ -65,11 +65,17 @@ func cleanupSnapshotResource(session *xenapi.Session, ref xenapi.VMRef) error {
 		return errors.New(err.Error())
 	}
 	for _, vbdRef := range vbdRefs {
-		vdiRef, err := xenapi.VBD.GetVDI(session, vbdRef)
+		vbdtype, err := xenapi.VBD.GetType(session, vbdRef)
 		if err != nil {
 			return errors.New(err.Error())
 		}
-		vdiRefs = append(vdiRefs, vdiRef)
+		if vbdtype == xenapi.VbdTypeDisk {
+			vdiRef, err := xenapi.VBD.GetVDI(session, vbdRef)
+			if err != nil {
+				return errors.New(err.Error())
+			}
+			vdiRefs = append(vdiRefs, vdiRef)
+		}
 	}
 	for _, vdiRef := range vdiRefs {
 		err = xenapi.VDI.Destroy(session, vdiRef)

--- a/xenserver/vm_utils.go
+++ b/xenserver/vm_utils.go
@@ -607,7 +607,7 @@ func getVBDsFromVMRecord(ctx context.Context, session *xenapi.Session, vmRecord 
 		if vbdRecord.VDI != "OpaqueRef:NULL" {
 			vdiRecord, err := xenapi.VDI.GetRecord(session, vbdRecord.VDI)
 			if err != nil {
-				return setValue, vbdSet, errors.New("!!!!!!unable to get VDI record")
+				return setValue, vbdSet, errors.New("unable to get VDI record")
 			}
 			vdiUUID = vdiRecord.UUID
 		}


### PR DESCRIPTION
test result:
```
ubuntu@ubuntu-server:~/code/terraform-provider-xenserver$ make testacc
if [ -z "/home/ubuntu/go/bin" ]; then echo "GOBIN is not set" && exit 1; fi
go mod tidy
go install .
ls -l /home/ubuntu/go/bin/terraform-provider-xenserver
-rwxrwxr-x 1 ubuntu ubuntu 23224141 Jul 26 10:42 /home/ubuntu/go/bin/terraform-provider-xenserver
source .env && TF_ACC=1 go test ./xenserver/ -v   -timeout 120m
=== RUN   TestAccNetworkDataSource
--- PASS: TestAccNetworkDataSource (0.70s)
=== RUN   TestAccVlanResource
--- PASS: TestAccVlanResource (3.64s)
=== RUN   TestAccNICDataSource
--- PASS: TestAccNICDataSource (0.82s)
=== RUN   TestAccPifDataSource
--- PASS: TestAccPifDataSource (0.66s)
=== RUN   TestAccSnapshotResource
--- PASS: TestAccSnapshotResource (6.92s)
=== RUN   TestAccSRDataSource
--- PASS: TestAccSRDataSource (0.66s)
=== RUN   TestAccNFSResource
--- PASS: TestAccNFSResource (5.50s)
=== RUN   TestAccSRResourceLocal
--- PASS: TestAccSRResourceLocal (5.05s)
=== RUN   TestAccSRResourceShared
--- PASS: TestAccSRResourceShared (4.80s)
=== RUN   TestAccVDIResource
--- PASS: TestAccVDIResource (6.67s)
=== RUN   TestAccVMDataSource
--- PASS: TestAccVMDataSource (2.79s)
=== RUN   TestAccVMResource
--- PASS: TestAccVMResource (4.46s)
PASS
ok      terraform-provider-xenserver/xenserver  42.690s
``` 