### PR TITLE
CA-396302: fix issues with win10 template

### DIFF
--- a/examples/vm-main/main.tf
+++ b/examples/vm-main/main.tf
@@ -23,12 +23,12 @@ data "xenserver_sr" "sr" {
 resource "xenserver_vdi" "vdi1" {
   name_label   = "local-storage-vdi-1"
   sr_uuid      = data.xenserver_sr.sr.data_items[0].uuid
-  virtual_size = 10 * 1024 * 1024 * 1024
+  virtual_size = 30 * 1024 * 1024 * 1024
 }
 resource "xenserver_vdi" "vdi2" {
   name_label   = "local-storage-vdi-2"
   sr_uuid      = data.xenserver_sr.sr.data_items[0].uuid
-  virtual_size = 10 * 1024 * 1024 * 1024
+  virtual_size = 30 * 1024 * 1024 * 1024
 }
 
 data "xenserver_network" "network" {}


### PR DESCRIPTION
test result:
```
ubuntu@ubuntu-server:~/code/terraform-provider-xenserver$ make testacc 
if [ -z "/home/ubuntu/go/bin" ]; then echo "GOBIN is not set" && exit 1; fi
go mod tidy
go install .
ls -l /home/ubuntu/go/bin/terraform-provider-xenserver
-rwxrwxr-x 1 ubuntu ubuntu 23224526 Jul 30 04:17 /home/ubuntu/go/bin/terraform-provider-xenserver
source .env && TF_ACC=1 go test ./xenserver/ -v   -timeout 120m
=== RUN   TestAccNetworkDataSource
--- PASS: TestAccNetworkDataSource (0.70s)
=== RUN   TestAccVlanResource
--- PASS: TestAccVlanResource (3.63s)
=== RUN   TestAccNICDataSource
--- PASS: TestAccNICDataSource (0.69s)
=== RUN   TestAccPifDataSource
--- PASS: TestAccPifDataSource (0.67s)
=== RUN   TestAccSnapshotResource
--- PASS: TestAccSnapshotResource (7.02s)
=== RUN   TestAccSRDataSource
--- PASS: TestAccSRDataSource (0.66s)
=== RUN   TestAccNFSResource
--- PASS: TestAccNFSResource (5.49s)
=== RUN   TestAccSRResourceLocal
--- PASS: TestAccSRResourceLocal (5.07s)
=== RUN   TestAccSRResourceShared
--- PASS: TestAccSRResourceShared (4.81s)
=== RUN   TestAccVDIResource
--- PASS: TestAccVDIResource (6.70s)
=== RUN   TestAccVMDataSource
--- PASS: TestAccVMDataSource (2.79s)
=== RUN   TestAccVMResource
--- PASS: TestAccVMResource (4.69s)
=== RUN   TestAccLinuxVMResource
--- PASS: TestAccLinuxVMResource (2.63s)
PASS
ok      terraform-provider-xenserver/xenserver  45.567s
``` 