### PR TITLE
CP-50354 Check IP

### DIFF
--- a/examples/vm-main/main.tf
+++ b/examples/vm-main/main.tf
@@ -34,7 +34,7 @@ resource "xenserver_vdi" "vdi2" {
 data "xenserver_network" "network" {}
 
 resource "xenserver_vm" "vm" {
-  name_label       = "A test virtual-machine"
+  name_label       = "Windows VM"
   template_name    = "Windows 11"
   static_mem_max   = 4 * 1024 * 1024 * 1024
   vcpus            = 4
@@ -67,7 +67,7 @@ resource "xenserver_vm" "vm" {
         ethtool-gso = "off"
       }
       mac          = "11:22:33:44:55:66"
-      network_uuid = data.xenserver_network.network.data_items[0].uuid,
+      network_uuid = data.xenserver_network.network.data_items[1].uuid,
     },
   ]
 

--- a/xenserver/network_data_source.go
+++ b/xenserver/network_data_source.go
@@ -172,6 +172,9 @@ func (d *networkDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		if !data.UUID.IsNull() && networkRecord.UUID != data.UUID.ValueString() {
 			continue
 		}
+		if networkRecord.NameLabel == "Host internal management network" {
+			continue
+		}
 
 		var networkData networkRecordData
 		err = updateNetworkRecordData(ctx, networkRecord, &networkData)
@@ -185,9 +188,9 @@ func (d *networkDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		networkItem = append(networkItem, networkData)
 	}
 
-	// sort networkItem by UUID
+	// sort networkItem by NameLabel
 	sort.Slice(networkItem, func(i, j int) bool {
-		return networkItem[i].UUID.ValueString() < networkItem[j].UUID.ValueString()
+		return networkItem[i].NameLabel.ValueString() < networkItem[j].NameLabel.ValueString()
 	})
 
 	data.DataItems = networkItem

--- a/xenserver/vm_resource_test.go
+++ b/xenserver/vm_resource_test.go
@@ -87,6 +87,8 @@ func TestAccVMResource(t *testing.T) {
 					resource.TestCheckResourceAttr("xenserver_vm.test_vm", "dynamic_mem_max", "4294967296"),
 					resource.TestCheckResourceAttr("xenserver_vm.test_vm", "vcpus", "4"),
 					resource.TestCheckResourceAttrSet("xenserver_vm.test_vm", "cores_per_socket"),
+					resource.TestCheckResourceAttr("xenserver_vm.test_vm", "check_ip_timeout", "0"),
+					resource.TestCheckResourceAttr("xenserver_vm.test_vm", "default_ip", ""),
 					resource.TestCheckResourceAttr("xenserver_vm.test_vm", "boot_mode", "uefi"),
 					resource.TestCheckResourceAttr("xenserver_vm.test_vm", "boot_order", "ncd"),
 					resource.TestCheckResourceAttr("xenserver_vm.test_vm", "hard_drive.#", "1"),


### PR DESCRIPTION
Tested with ssh connection
```
Plan: 1 to add, 0 to change, 1 to destroy.
xenserver_vm.linux_vm: Destroying... [id=5a16fbde-4253-d8ab-c613-c51153108b4c]
xenserver_vm.linux_vm: Destruction complete after 8s
xenserver_vm.linux_vm: Creating...
xenserver_vm.linux_vm: Still creating... [10s elapsed]
xenserver_vm.linux_vm: Still creating... [20s elapsed]
xenserver_vm.linux_vm: Still creating... [30s elapsed]
xenserver_vm.linux_vm: Still creating... [40s elapsed]
xenserver_vm.linux_vm: Provisioning with 'remote-exec'...
xenserver_vm.linux_vm (remote-exec): Connecting to remote host via SSH...
xenserver_vm.linux_vm (remote-exec):   Host: 10.71.153.62
xenserver_vm.linux_vm (remote-exec):   User: root
xenserver_vm.linux_vm (remote-exec):   Password: true
xenserver_vm.linux_vm (remote-exec):   Private key: false
xenserver_vm.linux_vm (remote-exec):   Certificate: false
xenserver_vm.linux_vm (remote-exec):   SSH Agent: false
xenserver_vm.linux_vm (remote-exec):   Checking Host Key: false
xenserver_vm.linux_vm (remote-exec):   Target Platform: unix
xenserver_vm.linux_vm (remote-exec): Connected!
xenserver_vm.linux_vm (remote-exec): PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
xenserver_vm.linux_vm (remote-exec): NAME="Debian GNU/Linux"
xenserver_vm.linux_vm (remote-exec): VERSION_ID="12"
xenserver_vm.linux_vm (remote-exec): VERSION="12 (bookworm)"
xenserver_vm.linux_vm (remote-exec): VERSION_CODENAME=bookworm
xenserver_vm.linux_vm (remote-exec): ID=debian
xenserver_vm.linux_vm (remote-exec): HOME_URL="https://www.debian.org/"
xenserver_vm.linux_vm (remote-exec): SUPPORT_URL="https://www.debian.org/support"
xenserver_vm.linux_vm (remote-exec): BUG_REPORT_URL="https://bugs.debian.org/"
xenserver_vm.linux_vm: Creation complete after 49s [id=f282c82a-43fc-e966-e440-6e2d9cf5a1ba]

Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
make[1]: Leaving directory '/home/feis/Documents/terraform-provider-xenserver'
```

Test Acc
```source .env && TF_ACC=1 go test ./xenserver/ -v   -timeout 120m
=== RUN   TestAccNetworkDataSource
--- PASS: TestAccNetworkDataSource (0.78s)
=== RUN   TestAccVlanResource
--- PASS: TestAccVlanResource (3.76s)
=== RUN   TestAccNICDataSource
--- PASS: TestAccNICDataSource (0.79s)
=== RUN   TestAccPifDataSource
--- PASS: TestAccPifDataSource (0.74s)
=== RUN   TestAccSnapshotResource
--- PASS: TestAccSnapshotResource (26.22s)
=== RUN   TestAccSRDataSource
--- PASS: TestAccSRDataSource (0.83s)
=== RUN   TestAccNFSResource
--- PASS: TestAccNFSResource (9.14s)
=== RUN   TestAccSRResourceLocal
--- PASS: TestAccSRResourceLocal (4.74s)
=== RUN   TestAccSRResourceShared
--- PASS: TestAccSRResourceShared (8.47s)
=== RUN   TestAccVDIResource
--- PASS: TestAccVDIResource (19.85s)
=== RUN   TestAccVMDataSource
--- PASS: TestAccVMDataSource (12.37s)
=== RUN   TestAccVMResource
--- PASS: TestAccVMResource (44.37s)
=== RUN   TestAccLinuxVMResource
--- PASS: TestAccLinuxVMResource (7.37s)
PASS
ok      terraform-provider-xenserver/xenserver  139.442s```