### PR TITLE
CA-396475 Pif data source not able to query with network as designed

### DIFF
--- a/xenserver/pif_data_source.go
+++ b/xenserver/pif_data_source.go
@@ -249,8 +249,18 @@ func (d *pifDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 
 	var pifItems []pifRecordData
 	for _, pifRecord := range pifRecords {
-		if !data.Network.IsNull() && string(pifRecord.Network) != data.Network.ValueString() {
-			continue
+		if !data.Network.IsNull() {
+			NetworkRef, err := xenapi.Network.GetByUUID(d.session, data.Network.ValueString())
+			if err != nil {
+				resp.Diagnostics.AddError(
+					"Unable to get network reference",
+					err.Error(),
+				)
+				return
+			}
+			if pifRecord.Network != NetworkRef {
+				continue
+			}
 		}
 
 		if !data.Device.IsNull() && pifRecord.Device != data.Device.ValueString() {

--- a/xenserver/pif_data_source_test.go
+++ b/xenserver/pif_data_source_test.go
@@ -16,6 +16,15 @@ data "xenserver_pif" "test_pif_data" {
 `, device)
 }
 
+func testAccPifDataSourceConfig1() string {
+	return `
+data "xenserver_network" "test_network_data" {}
+data "xenserver_pif" "test_pif_data" {
+    network = data.xenserver_network.test_network_data.data_items[0].uuid
+}
+`
+}
+
 func TestAccPifDataSource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -27,6 +36,12 @@ func TestAccPifDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.xenserver_pif.test_pif_data", "device", "eth0"),
 					resource.TestCheckResourceAttr("data.xenserver_pif.test_pif_data", "management", "true"),
 					resource.TestCheckResourceAttrSet("data.xenserver_pif.test_pif_data", "data_items.#"),
+				),
+			},
+			{
+				Config: providerConfig + testAccPifDataSourceConfig1(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.xenserver_pif.test_pif_data", "data_items.#", "1"),
 				),
 			},
 		},


### PR DESCRIPTION
```
source .env && TF_ACC=1 go test ./xenserver/ -v   -timeout 120m
=== RUN   TestAccNetworkDataSource
--- PASS: TestAccNetworkDataSource (0.83s)
=== RUN   TestAccVlanResource
--- PASS: TestAccVlanResource (3.62s)
=== RUN   TestAccNICDataSource
--- PASS: TestAccNICDataSource (0.75s)
=== RUN   TestAccPifDataSource
--- PASS: TestAccPifDataSource (1.31s)
=== RUN   TestAccSnapshotResource
--- PASS: TestAccSnapshotResource (6.38s)
=== RUN   TestAccSRDataSource
--- PASS: TestAccSRDataSource (0.78s)
=== RUN   TestAccNFSResource
--- PASS: TestAccNFSResource (8.85s)
=== RUN   TestAccSRResourceLocal
--- PASS: TestAccSRResourceLocal (4.82s)
=== RUN   TestAccSRResourceShared
--- PASS: TestAccSRResourceShared (8.17s)
=== RUN   TestAccVDIResource
--- PASS: TestAccVDIResource (13.05s)
=== RUN   TestAccVMDataSource
--- PASS: TestAccVMDataSource (2.39s)
=== RUN   TestAccVMResource
--- PASS: TestAccVMResource (4.59s)
=== RUN   TestAccLinuxVMResource
--- PASS: TestAccLinuxVMResource (2.34s)
PASS
ok      terraform-provider-xenserver/xenserver  57.885s```