### PR TITLE
CA-396481: VM create from custom template do not have start/shutdown in allow operations

### DIFF
--- a/xenserver/vm_resouce.go
+++ b/xenserver/vm_resouce.go
@@ -187,10 +187,11 @@ func (r *vmResource) Update(ctx context.Context, req resource.UpdateRequest, res
 		return
 	}
 
-	if plan.TemplateName != state.TemplateName {
+	err := vmResourceModelUpdateCheck(plan, state)
+	if err != nil {
 		resp.Diagnostics.AddError(
-			"The template name doesn't expected to be updated",
-			"plan.TemplateName: "+plan.TemplateName.ValueString()+"  state.TemplateName: "+state.TemplateName.ValueString(),
+			"Error update xenserver_vm configuration",
+			err.Error(),
 		)
 		return
 	}

--- a/xenserver/vm_resource_test.go
+++ b/xenserver/vm_resource_test.go
@@ -108,8 +108,16 @@ func TestAccVMResource(t *testing.T) {
 			},
 			// Update with expected failure
 			{
+				Config:      providerConfig + testAccVMResourceConfig("test vm 1", "Windows 10", 3, 4, 2, "uefi", "ncd", "true", "RW", "11:22:33:44:55:66", "0"),
+				ExpectError: regexp.MustCompile(`"template_name" doesn't expected to be updated*`),
+			},
+			{
+				Config:      providerConfig + testAccVMResourceConfig("test vm 1", "Windows 11", 3, 4, 2, "bios", "ncd", "true", "RW", "11:22:33:44:55:66", "0"),
+				ExpectError: regexp.MustCompile(`"boot_mode" doesn't expected to be updated*`),
+			},
+			{
 				Config:      providerConfig + testAccVMResourceConfig("test vm 1", "Windows 11", 3, 4, 2, "uefi", "ncd", "true", "RW", "44:55:66:11:22:33", "0"),
-				ExpectError: regexp.MustCompile(`"network_interface.mac" doesn't expected to be updated.*`),
+				ExpectError: regexp.MustCompile(`"network_interface.mac" doesn't expected to be updated*`),
 			},
 			{
 				Config:      providerConfig + testAccVMResourceConfig("test vm 1", "Windows 11", 3, 3, 2, "uefi", "ncd", "false", "RO", "11:22:33:44:55:66", "1"),
@@ -118,7 +126,7 @@ func TestAccVMResource(t *testing.T) {
 			// Update and Read testing
 			// change the network_interface device
 			{
-				Config: providerConfig + testAccVMResourceConfig("test vm 1", "Windows 11", 3, 2, 2, "uefi_security", "cnd", "false", "RO", "11:22:33:44:55:66", "1"),
+				Config: providerConfig + testAccVMResourceConfig("test vm 1", "Windows 11", 3, 2, 2, "uefi", "cnd", "false", "RO", "11:22:33:44:55:66", "1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("xenserver_vm.test_vm", "name_label", "test vm 1"),
 					resource.TestCheckResourceAttr("xenserver_vm.test_vm", "template_name", "Windows 11"),
@@ -131,7 +139,7 @@ func TestAccVMResource(t *testing.T) {
 					resource.TestCheckResourceAttr("xenserver_vm.test_vm", "hard_drive.#", "1"),
 					resource.TestCheckResourceAttr("xenserver_vm.test_vm", "hard_drive.0.mode", "RO"),
 					resource.TestCheckResourceAttr("xenserver_vm.test_vm", "hard_drive.0.bootable", "false"),
-					resource.TestCheckResourceAttr("xenserver_vm.test_vm", "boot_mode", "uefi_security"),
+					resource.TestCheckResourceAttr("xenserver_vm.test_vm", "boot_mode", "uefi"),
 					resource.TestCheckResourceAttr("xenserver_vm.test_vm", "boot_order", "cnd"),
 					resource.TestCheckResourceAttr("xenserver_vm.test_vm", "network_interface.#", "1"),
 					resource.TestCheckResourceAttr("xenserver_vm.test_vm", "network_interface.0.device", "1"),


### PR DESCRIPTION
test result:
```
ubuntu@ubuntu-server:~/code/terraform-provider-xenserver$ make testacc 
if [ -z "/home/ubuntu/go/bin" ]; then echo "GOBIN is not set" && exit 1; fi
go mod tidy
go install .
ls -l /home/ubuntu/go/bin/terraform-provider-xenserver
-rwxrwxr-x 1 ubuntu ubuntu 23265299 Jul 31 10:36 /home/ubuntu/go/bin/terraform-provider-xenserver
source .env && TF_ACC=1 go test ./xenserver/ -v   -timeout 120m
=== RUN   TestAccNetworkDataSource
--- PASS: TestAccNetworkDataSource (0.66s)
=== RUN   TestAccVlanResource
--- PASS: TestAccVlanResource (3.04s)
=== RUN   TestAccNICDataSource
--- PASS: TestAccNICDataSource (0.62s)
=== RUN   TestAccPifDataSource
--- PASS: TestAccPifDataSource (1.08s)
=== RUN   TestAccSnapshotResource
--- PASS: TestAccSnapshotResource (5.14s)
=== RUN   TestAccSRDataSource
--- PASS: TestAccSRDataSource (0.63s)
=== RUN   TestAccNFSResource
--- PASS: TestAccNFSResource (7.32s)
=== RUN   TestAccSRResourceLocal
--- PASS: TestAccSRResourceLocal (4.12s)
=== RUN   TestAccSRResourceShared
--- PASS: TestAccSRResourceShared (6.68s)
=== RUN   TestAccVDIResource
--- PASS: TestAccVDIResource (11.00s)
=== RUN   TestAccVMDataSource
--- PASS: TestAccVMDataSource (2.07s)
=== RUN   TestAccVMResource
--- PASS: TestAccVMResource (3.55s)
=== RUN   TestAccLinuxVMResource
--- PASS: TestAccLinuxVMResource (1.95s)
PASS
ok      terraform-provider-xenserver/xenserver  47.883s
``` 
