### PR TITLE
CP-51463: Implement smb/nfs resource for iso library

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ The XenServer provider can be used to manage and deploy XenServer resources. Bef
 
 ```terraform
 provider "xenserver" {
-  host     = "https://1.1.1.1"
+  host     = "https://10.1.1.1"
   username = "root"
   password = "test123"
 }

--- a/docs/resources/sr.md
+++ b/docs/resources/sr.md
@@ -29,8 +29,8 @@ resource "xenserver_sr" "nfs" {
   content_type = ""
   shared       = true
   device_config = {
-    server     = "1.1.1.1"
-    serverpath = "/server/path"
+    server     = "10.1.1.1"
+    serverpath = "/path"
     nfsversion = "3"
   }
   sm_config = {

--- a/docs/resources/sr_nfs.md
+++ b/docs/resources/sr_nfs.md
@@ -17,7 +17,15 @@ resource "xenserver_sr_nfs" "nfs_test" {
   name_label       = "NFS virtual disk storage"
   name_description = "A test NFS storage repository"
   version          = "3"
-  storage_location = "1.1.1.1:/server/path"
+  storage_location = "server:/path"
+}
+
+resource "xenserver_sr_nfs" "nfs_iso_test" {
+  name_label       = "NFS ISO library"
+  name_description = "A test NFS ISO library"
+  type             = "iso"
+  version          = "4"
+  storage_location = "server:/path"
 }
 ```
 
@@ -27,7 +35,7 @@ resource "xenserver_sr_nfs" "nfs_test" {
 ### Required
 
 - `name_label` (String) The name of the NFS storage repository.
-- `storage_location` (String) The server and server path of the NFS storage repository.<br />Follow the format `"1.1.1.1:/server/path"`.
+- `storage_location` (String) The server and server path of the NFS storage repository.<br />Follow the format `"server:/path"`.
 
 -> **Note:** `storage_location` is not allowed to be updated.
 - `version` (String) The version of NFS storage repository.<br />Can be set as `"3"` or `"4"`.
@@ -40,6 +48,9 @@ resource "xenserver_sr_nfs" "nfs_test" {
 
 -> **Note:** `advanced_options` is not allowed to be updated.
 - `name_description` (String) The description of the NFS storage repository, default to be `""`.
+- `type` (String) The type of the NFS storage repository, default to be `"nfs"`.<br />Can be set as `"nfs"` or `"iso"`.
+
+-> **Note:** `type` is not allowed to be updated.
 
 ### Read-Only
 

--- a/docs/resources/sr_smb.md
+++ b/docs/resources/sr_smb.md
@@ -21,8 +21,25 @@ resource "xenserver_sr_smb" "smb_test" {
   password         = "password"
 }
 
-resource "xenserver_sr_smb" "smb_test" {
+resource "xenserver_sr_smb" "smb_test1" {
   name_label       = "SMB storage"
+  storage_location = <<-EOF
+    \\server\path
+EOF
+}
+
+resource "xenserver_sr_smb" "smb_iso_test" {
+  name_label       = "SMB ISO library"
+  name_description = "A test SMB ISO library"
+  type             = "iso"
+  storage_location = "\\\\server\\path"
+  username         = "username"
+  password         = "password"
+}
+
+resource "xenserver_sr_smb" "smb_iso_test1" {
+  name_label       = "SMB ISO library"
+  type             = "iso"
   storage_location = <<-EOF
     \\server\path
 EOF
@@ -45,6 +62,9 @@ EOF
 - `password` (String, Sensitive) The password of the SMB storage repository. Used when creating the SR.
 
 -> **Note:** This password will be stored in terraform state file, follow document [Sensitive values in state](https://developer.hashicorp.com/terraform/tutorials/configuration-language/sensitive-variables#sensitive-values-in-state) to protect your sensitive data.
+- `type` (String) The type of the SMB storage repository, default to be `"smb"`.<br />Can be set as `"smb"` or `"iso"`.
+
+-> **Note:** `type` is not allowed to be updated.
 - `username` (String) The username of the SMB storage repository. Used when creating the SR.
 
 ### Read-Only

--- a/docs/resources/vdi.md
+++ b/docs/resources/vdi.md
@@ -18,7 +18,7 @@ resource "xenserver_sr_nfs" "nfs" {
   name_label       = "Test NFS SR"
   name_description = "A test NFS storage repository"
   version          = "3"
-  storage_location = "1.1.1.1:/server/path"
+  storage_location = "10.1.1.1:/server/path"
 }
 
 resource "xenserver_vdi" "vdi" {

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,5 +1,5 @@
 provider "xenserver" {
-  host     = "https://1.1.1.1"
+  host     = "https://10.1.1.1"
   username = "root"
   password = "test123"
 }

--- a/examples/resources/xenserver_sr/resource.tf
+++ b/examples/resources/xenserver_sr/resource.tf
@@ -14,8 +14,8 @@ resource "xenserver_sr" "nfs" {
   content_type = ""
   shared       = true
   device_config = {
-    server     = "1.1.1.1"
-    serverpath = "/server/path"
+    server     = "10.1.1.1"
+    serverpath = "/path"
     nfsversion = "3"
   }
   sm_config = {

--- a/examples/resources/xenserver_sr_nfs/resource.tf
+++ b/examples/resources/xenserver_sr_nfs/resource.tf
@@ -2,5 +2,13 @@ resource "xenserver_sr_nfs" "nfs_test" {
   name_label       = "NFS virtual disk storage"
   name_description = "A test NFS storage repository"
   version          = "3"
-  storage_location = "1.1.1.1:/server/path"
+  storage_location = "server:/path"
+}
+
+resource "xenserver_sr_nfs" "nfs_iso_test" {
+  name_label       = "NFS ISO library"
+  name_description = "A test NFS ISO library"
+  type             = "iso"
+  version          = "4"
+  storage_location = "server:/path"
 }

--- a/examples/resources/xenserver_sr_smb/resource.tf
+++ b/examples/resources/xenserver_sr_smb/resource.tf
@@ -6,8 +6,25 @@ resource "xenserver_sr_smb" "smb_test" {
   password         = "password"
 }
 
-resource "xenserver_sr_smb" "smb_test" {
+resource "xenserver_sr_smb" "smb_test1" {
   name_label       = "SMB storage"
+  storage_location = <<-EOF
+    \\server\path
+EOF
+}
+
+resource "xenserver_sr_smb" "smb_iso_test" {
+  name_label       = "SMB ISO library"
+  name_description = "A test SMB ISO library"
+  type             = "iso"
+  storage_location = "\\\\server\\path"
+  username         = "username"
+  password         = "password"
+}
+
+resource "xenserver_sr_smb" "smb_iso_test1" {
+  name_label       = "SMB ISO library"
+  type             = "iso"
   storage_location = <<-EOF
     \\server\path
 EOF

--- a/examples/resources/xenserver_vdi/resource.tf
+++ b/examples/resources/xenserver_vdi/resource.tf
@@ -3,7 +3,7 @@ resource "xenserver_sr_nfs" "nfs" {
   name_label       = "Test NFS SR"
   name_description = "A test NFS storage repository"
   version          = "3"
-  storage_location = "1.1.1.1:/server/path"
+  storage_location = "10.1.1.1:/server/path"
 }
 
 resource "xenserver_vdi" "vdi" {

--- a/examples/terraform-main/main.tf
+++ b/examples/terraform-main/main.tf
@@ -56,6 +56,13 @@ resource "xenserver_sr_smb" "smb_test" {
   storage_location = local.env_vars["SMB_SERVER_PATH"]
 }
 
+resource "xenserver_sr_smb" "smb_iso_test" {
+  name_label       = "SMB ISO library"
+  name_description = "A test SMB ISO library"
+  type             = "iso"
+  storage_location = local.env_vars["SMB_SERVER_PATH"]
+}
+
 resource "xenserver_sr" "nfs" {
   name_label = "Test NFS SR"
   type       = "nfs"
@@ -68,6 +75,14 @@ resource "xenserver_sr" "nfs" {
 
 output "sr_nfs_out" {
   value = xenserver_sr.nfs
+}
+
+resource "xenserver_sr_nfs" "nfs_iso_test" {
+  name_label       = "NFS ISO library"
+  name_description = "A test NFS ISO library description"
+  type             = "iso"
+  version          = "4"
+  storage_location = format("%s:%s", local.env_vars["NFS_SERVER"], local.env_vars["NFS_SERVER_PATH"])
 }
 
 resource "xenserver_sr_nfs" "nfs_test" {

--- a/xenserver/pif_data_source_test.go
+++ b/xenserver/pif_data_source_test.go
@@ -2,9 +2,11 @@ package xenserver
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func testAccPifDataSourceConfig(device string) string {
@@ -40,8 +42,23 @@ func TestAccPifDataSource(t *testing.T) {
 			},
 			{
 				Config: providerConfig + testAccPifDataSourceConfig1(),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.xenserver_pif.test_pif_data", "data_items.#", "1"),
+				Check: resource.ComposeTestCheckFunc(
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["data.xenserver_pif.test_pif_data"]
+						if !ok {
+							return fmt.Errorf("Not found: %s", "data.xenserver_pif.test_pif_data")
+						}
+						// the length of data_items depends on the number of hosts in the pool
+						attr := rs.Primary.Attributes["data_items.#"]
+						value, err := strconv.Atoi(attr)
+						if err != nil {
+							return fmt.Errorf("Error converting attribute value to integer: %w", err)
+						}
+						if value < 1 {
+							return fmt.Errorf("Expected length of data_items to be greater than 0, got: %d", value)
+						}
+						return nil
+					},
 				),
 			},
 		},

--- a/xenserver/sr_nfs_resource.go
+++ b/xenserver/sr_nfs_resource.go
@@ -51,9 +51,20 @@ func (r *nfsResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				Computed:            true,
 				Default:             stringdefault.StaticString(""),
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: "The type of the NFS storage repository, default to be `\"nfs\"`." + "<br />" +
+					"Can be set as `\"nfs\"` or `\"iso\"`." +
+					"\n\n-> **Note:** `type` is not allowed to be updated.",
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString("nfs"),
+				Validators: []validator.String{
+					stringvalidator.OneOf("nfs", "iso"),
+				},
+			},
 			"storage_location": schema.StringAttribute{
 				MarkdownDescription: "The server and server path of the NFS storage repository." + "<br />" +
-					"Follow the format `\"1.1.1.1:/server/path\"`." +
+					"Follow the format `\"server:/path\"`." +
 					"\n\n-> **Note:** `storage_location` is not allowed to be updated.",
 				Required: true,
 			},

--- a/xenserver/sr_nfs_resource_test.go
+++ b/xenserver/sr_nfs_resource_test.go
@@ -36,6 +36,7 @@ func TestAccNFSResource(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("xenserver_sr_nfs.test_nfs", "name_label", "Test NFS storage repository"),
 					resource.TestCheckResourceAttr("xenserver_sr_nfs.test_nfs", "name_description", ""),
+					resource.TestCheckResourceAttr("xenserver_sr_nfs.test_nfs", "type", "nfs"),
 					resource.TestCheckResourceAttr("xenserver_sr_nfs.test_nfs", "storage_location", storage_location),
 					resource.TestCheckResourceAttr("xenserver_sr_nfs.test_nfs", "version", "3"),
 					resource.TestCheckResourceAttr("xenserver_sr_nfs.test_nfs", "advanced_options", ""),
@@ -69,6 +70,61 @@ func TestAccNFSResource(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("xenserver_sr_nfs.test_nfs", "name_label", "Test NFS storage repository 2"),
 					resource.TestCheckResourceAttr("xenserver_sr_nfs.test_nfs", "name_description", "Test NFS Description"),
+					resource.TestCheckResourceAttr("xenserver_sr_nfs.test_nfs", "type", "nfs"),
+					resource.TestCheckResourceAttr("xenserver_sr_nfs.test_nfs", "storage_location", os.Getenv("NFS_SERVER")+":"+os.Getenv("NFS_SERVER_PATH")),
+					resource.TestCheckResourceAttr("xenserver_sr_nfs.test_nfs", "version", "3"),
+					resource.TestCheckResourceAttr("xenserver_sr_nfs.test_nfs", "advanced_options", ""),
+					// Verify dynamic values have any value set in the state.
+					resource.TestCheckResourceAttrSet("xenserver_sr_nfs.test_nfs", "uuid"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func TestAccNFSISOResource(t *testing.T) {
+	storage_location := os.Getenv("NFS_SERVER") + ":" + os.Getenv("NFS_SERVER_PATH")
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config:      providerConfig + testAccNFSResourceConfig("Test NFS ISO library", "", "3", storage_location, "type = \"other-type\""),
+				ExpectError: regexp.MustCompile(`Invalid Attribute Value Match`),
+			},
+			{
+				Config: providerConfig + testAccNFSResourceConfig("Test NFS ISO library", "", "3", storage_location, "type = \"iso\""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("xenserver_sr_nfs.test_nfs", "name_label", "Test NFS ISO library"),
+					resource.TestCheckResourceAttr("xenserver_sr_nfs.test_nfs", "name_description", ""),
+					resource.TestCheckResourceAttr("xenserver_sr_nfs.test_nfs", "type", "iso"),
+					resource.TestCheckResourceAttr("xenserver_sr_nfs.test_nfs", "storage_location", storage_location),
+					resource.TestCheckResourceAttr("xenserver_sr_nfs.test_nfs", "version", "3"),
+					resource.TestCheckResourceAttr("xenserver_sr_nfs.test_nfs", "advanced_options", ""),
+					// Verify dynamic values have any value set in the state.
+
+					resource.TestCheckResourceAttrSet("xenserver_sr_nfs.test_nfs", "uuid"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:            "xenserver_sr_nfs.test_nfs",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+			{
+				Config:      providerConfig + testAccNFSResourceConfig("Test NFS ISO library", "", "3", storage_location, "type = \"nfs\""),
+				ExpectError: regexp.MustCompile(`"type" doesn't expected to be updated`),
+			},
+			// Update and Read testing
+			{
+				Config: providerConfig + testAccNFSResourceConfig("Test NFS ISO library 2", "Test NFS ISO library Description", "3", storage_location, "type = \"iso\""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("xenserver_sr_nfs.test_nfs", "name_label", "Test NFS ISO library 2"),
+					resource.TestCheckResourceAttr("xenserver_sr_nfs.test_nfs", "name_description", "Test NFS ISO library Description"),
+					resource.TestCheckResourceAttr("xenserver_sr_nfs.test_nfs", "type", "iso"),
 					resource.TestCheckResourceAttr("xenserver_sr_nfs.test_nfs", "storage_location", os.Getenv("NFS_SERVER")+":"+os.Getenv("NFS_SERVER_PATH")),
 					resource.TestCheckResourceAttr("xenserver_sr_nfs.test_nfs", "version", "3"),
 					resource.TestCheckResourceAttr("xenserver_sr_nfs.test_nfs", "advanced_options", ""),

--- a/xenserver/sr_smb_resource.go
+++ b/xenserver/sr_smb_resource.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"xenapi"
@@ -48,6 +50,17 @@ func (r *smbResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				Optional:            true,
 				Computed:            true,
 				Default:             stringdefault.StaticString(""),
+			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: "The type of the SMB storage repository, default to be `\"smb\"`." + "<br />" +
+					"Can be set as `\"smb\"` or `\"iso\"`." +
+					"\n\n-> **Note:** `type` is not allowed to be updated.",
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString("smb"),
+				Validators: []validator.String{
+					stringvalidator.OneOf("smb", "iso"),
+				},
 			},
 			"storage_location": schema.StringAttribute{
 				MarkdownDescription: "The server and server path of the SMB storage repository." + "<br />" +

--- a/xenserver/sr_smb_resource_test.go
+++ b/xenserver/sr_smb_resource_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func testAccSMBResourceConfig(name_label string, name_description string, storage_location string, username string, password string) string {
+func testAccSMBResourceConfig(name_label string, name_description string, storage_location string, username string, password string, extra_config string) string {
 	return fmt.Sprintf(`
 resource "xenserver_sr_smb" "test_smb" {
 	name_label       = "%s"
@@ -18,8 +18,9 @@ resource "xenserver_sr_smb" "test_smb" {
 	storage_location = "%s"
 	username         = "%s"
 	password         = "%s"
+	%s
 }
-`, name_label, name_description, storage_location, username, password)
+`, name_label, name_description, storage_location, username, password, extra_config)
 }
 
 func TestAccSMBResource(t *testing.T) {
@@ -33,10 +34,11 @@ func TestAccSMBResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: providerConfig + testAccSMBResourceConfig("Test SMB storage repository", "", storage_location, username, password),
+				Config: providerConfig + testAccSMBResourceConfig("Test SMB storage repository", "", storage_location, username, password, ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("xenserver_sr_smb.test_smb", "name_label", "Test SMB storage repository"),
 					resource.TestCheckResourceAttr("xenserver_sr_smb.test_smb", "name_description", ""),
+					resource.TestCheckResourceAttr("xenserver_sr_smb.test_smb", "type", "smb"),
 					resource.TestCheckResourceAttr("xenserver_sr_smb.test_smb", "storage_location", expected_storage_location),
 					resource.TestCheckResourceAttr("xenserver_sr_smb.test_smb", "username", username),
 					resource.TestCheckResourceAttr("xenserver_sr_smb.test_smb", "password", password),
@@ -53,15 +55,74 @@ func TestAccSMBResource(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"username", "password"},
 			},
 			{
-				Config:      providerConfig + testAccSMBResourceConfig("Test SMB storage repository 2", "Test SMB Description", "", username, password),
+				Config:      providerConfig + testAccSMBResourceConfig("Test SMB storage repository 2", "Test SMB Description", "", username, password, ""),
 				ExpectError: regexp.MustCompile(`"storage_location" doesn't expected to be updated`),
 			},
 			// Update and Read testing
 			{
-				Config: providerConfig + testAccSMBResourceConfig("Test SMB storage repository 2", "Test SMB Description", storage_location, username, password),
+				Config: providerConfig + testAccSMBResourceConfig("Test SMB storage repository 2", "Test SMB Description", storage_location, username, password, ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("xenserver_sr_smb.test_smb", "name_label", "Test SMB storage repository 2"),
 					resource.TestCheckResourceAttr("xenserver_sr_smb.test_smb", "name_description", "Test SMB Description"),
+					resource.TestCheckResourceAttr("xenserver_sr_smb.test_smb", "type", "smb"),
+					resource.TestCheckResourceAttr("xenserver_sr_smb.test_smb", "storage_location", expected_storage_location),
+					resource.TestCheckResourceAttr("xenserver_sr_smb.test_smb", "username", username),
+					resource.TestCheckResourceAttr("xenserver_sr_smb.test_smb", "password", password),
+					// Verify dynamic values have any value set in the state.
+					resource.TestCheckResourceAttrSet("xenserver_sr_smb.test_smb", "uuid"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func TestAccSMBISOResource(t *testing.T) {
+	// SMB_SERVER_PATH should be like '\\\\10.70.41.7\\share', then expected_storage_location is '\\10.70.41.7\share'
+	expected_storage_location := os.Getenv("SMB_SERVER_PATH")
+	storage_location := strings.ReplaceAll(expected_storage_location, "\\", "\\\\")
+	username := os.Getenv("SMB_SERVER_USERNAME")
+	password := os.Getenv("SMB_SERVER_PASSWORD")
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config:      providerConfig + testAccSMBResourceConfig("Test SMB ISO library", "", storage_location, username, password, "type = \"other-type\""),
+				ExpectError: regexp.MustCompile(`Invalid Attribute Value Match`),
+			},
+			{
+				Config: providerConfig + testAccSMBResourceConfig("Test SMB ISO library", "", storage_location, username, password, "type = \"iso\""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("xenserver_sr_smb.test_smb", "name_label", "Test SMB ISO library"),
+					resource.TestCheckResourceAttr("xenserver_sr_smb.test_smb", "name_description", ""),
+					resource.TestCheckResourceAttr("xenserver_sr_smb.test_smb", "type", "iso"),
+					resource.TestCheckResourceAttr("xenserver_sr_smb.test_smb", "storage_location", expected_storage_location),
+					resource.TestCheckResourceAttr("xenserver_sr_smb.test_smb", "username", username),
+					resource.TestCheckResourceAttr("xenserver_sr_smb.test_smb", "password", password),
+					// Verify dynamic values have any value set in the state.
+
+					resource.TestCheckResourceAttrSet("xenserver_sr_smb.test_smb", "uuid"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:            "xenserver_sr_smb.test_smb",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"username", "password"},
+			},
+			{
+				Config:      providerConfig + testAccSMBResourceConfig("Test SMB ISO library 2", "Test SMB Description", "", username, password, "type = \"smb\""),
+				ExpectError: regexp.MustCompile(`"type" doesn't expected to be updated`),
+			},
+			// Update and Read testing
+			{
+				Config: providerConfig + testAccSMBResourceConfig("Test SMB ISO library 2", "Test SMB Description", storage_location, username, password, "type = \"iso\""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("xenserver_sr_smb.test_smb", "name_label", "Test SMB ISO library 2"),
+					resource.TestCheckResourceAttr("xenserver_sr_smb.test_smb", "name_description", "Test SMB Description"),
+					resource.TestCheckResourceAttr("xenserver_sr_smb.test_smb", "type", "iso"),
 					resource.TestCheckResourceAttr("xenserver_sr_smb.test_smb", "storage_location", expected_storage_location),
 					resource.TestCheckResourceAttr("xenserver_sr_smb.test_smb", "username", username),
 					resource.TestCheckResourceAttr("xenserver_sr_smb.test_smb", "password", password),


### PR DESCRIPTION
test result:
```
ubuntu@ubuntu-server:~/code/terraform-provider-xenserver$ make testacc
if [ -z "/home/ubuntu/go/bin" ]; then echo "GOBIN is not set" && exit 1; fi
go mod tidy
go install .
ls -l /home/ubuntu/go/bin/terraform-provider-xenserver
-rwxrwxr-x 1 ubuntu ubuntu 23329138 Oct  8 09:18 /home/ubuntu/go/bin/terraform-provider-xenserver
source .env && TF_ACC=1 go test ./xenserver/ -v   -timeout 120m
=== RUN   TestAccNetworkDataSource
--- PASS: TestAccNetworkDataSource (1.00s)
=== RUN   TestAccVlanResource
--- PASS: TestAccVlanResource (9.54s)
=== RUN   TestAccNICDataSource
--- PASS: TestAccNICDataSource (0.98s)
=== RUN   TestAccPifDataSource
--- PASS: TestAccPifDataSource (1.77s)
=== RUN   TestAccSnapshotResource
--- PASS: TestAccSnapshotResource (13.25s)
=== RUN   TestAccSRDataSource
--- PASS: TestAccSRDataSource (0.96s)
=== RUN   TestAccNFSResource
--- PASS: TestAccNFSResource (9.62s)
=== RUN   TestAccNFSISOResource
--- PASS: TestAccNFSISOResource (8.56s)
=== RUN   TestAccSRResourceLocal
--- PASS: TestAccSRResourceLocal (8.63s)
=== RUN   TestAccSRResourceShared
--- PASS: TestAccSRResourceShared (8.59s)
=== RUN   TestAccSMBResource
--- PASS: TestAccSMBResource (8.66s)
=== RUN   TestAccSMBISOResource
--- PASS: TestAccSMBISOResource (8.32s)
=== RUN   TestAccVDIResource
--- PASS: TestAccVDIResource (11.76s)
=== RUN   TestAccVMDataSource
--- PASS: TestAccVMDataSource (4.85s)
=== RUN   TestAccVMResource
--- PASS: TestAccVMResource (8.99s)
=== RUN   TestAccLinuxVMResource
--- PASS: TestAccLinuxVMResource (5.16s)
PASS
ok      terraform-provider-xenserver/xenserver  110.654s
``` 