### PR TITLE
CA-401363 Remove backoff retries on terraform destroy

### DIFF
--- a/xenserver/pool_utils.go
+++ b/xenserver/pool_utils.go
@@ -308,11 +308,7 @@ func cleanupPoolResource(session *xenapi.Session, poolRef xenapi.PoolRef) error 
 			continue
 		}
 
-		operation := func() error {
-			return xenapi.Pool.Eject(session, hostRef)
-		}
-
-		err = backoff.Retry(operation, backoff.NewExponentialBackOff())
+		err = xenapi.Pool.Eject(session, hostRef)
 		if err != nil {
 			return errors.New(err.Error())
 		}

--- a/xenserver/vm_utils.go
+++ b/xenserver/vm_utils.go
@@ -624,17 +624,19 @@ func updateVMResourceModelComputed(ctx context.Context, session *xenapi.Session,
 		return err
 	}
 
-	checkIPDuration, err := strconv.Atoi(vmRecord.OtherConfig["tf_check_ip_timeout"])
-	if err != nil {
-		return errors.New("unable to convert check_ip_timeout to an int value")
-	}
-	data.CheckIPTimeout = types.Int64Value(int64(checkIPDuration))
+	if _, ok := vmRecord.OtherConfig["tf_check_ip_timeout"]; ok {
+		checkIPDuration, err := strconv.Atoi(vmRecord.OtherConfig["tf_check_ip_timeout"])
+		if err != nil {
+			return errors.New("unable to convert check_ip_timeout to an int value")
+		}
+		data.CheckIPTimeout = types.Int64Value(int64(checkIPDuration))
 
-	ip, err := checkIP(ctx, session, vmRecord)
-	if err != nil {
-		return err
+		ip, err := checkIP(ctx, session, vmRecord)
+		if err != nil {
+			return err
+		}
+		data.DefaultIP = types.StringValue(ip)
 	}
-	data.DefaultIP = types.StringValue(ip)
 
 	return nil
 }


### PR DESCRIPTION
```
# terraform import xenserver_vm.vm 39dc1d95-9b6b-23e4-e7a1-32bcfc524051
xenserver_vm.vm: Importing from ID "39dc1d95-9b6b-23e4-e7a1-32bcfc524051"...
xenserver_vm.vm: Import prepared!
  Prepared xenserver_vm for import
xenserver_vm.vm: Refreshing state...

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```