### PR TITLE
CP-51659: Create VM from Template with Full Disk Copy

### DIFF
--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -74,6 +74,23 @@ resource "xenserver_vm" "windows_vm" {
   }
 }
 
+# Create a Windows 11 VM that is copy from the custom template
+resource "xenserver_vm" "windows_vm_copy" {
+  name_label       = "Windows VM Copy From Custom Template"
+  template_name    = "Custom Windows 11 Template"
+  static_mem_max   = 4 * 1024 * 1024 * 1024
+  vcpus            = 4
+  cores_per_socket = 2
+  sr_for_full_disk_copy = data.xenserver_sr.sr.data_items[0].uuid
+
+  network_interface = [
+    {
+      device       = "0"
+      network_uuid = data.xenserver_network.network.data_items[0].uuid,
+    },
+  ]
+}
+
 # Create a Linux VM that is cloned from the custom template
 resource "xenserver_vm" "linux_vm" {
   name_label       = "Linux VM"
@@ -200,6 +217,9 @@ output "vm_out" {
 - `hard_drive` (Attributes Set) A set of hard drive attributes to attach to the virtual machine, default inherited from the template. (see [below for nested schema](#nestedatt--hard_drive))
 - `name_description` (String) The description of the virtual machine, default to be `""`.
 - `other_config` (Map of String) The additional configuration of the virtual machine, default to be `{}`.
+- `sr_for_full_disk_copy` (String) Use storage-level full disk copy. Give a SR uuid or set as `"origin"` to keep use the origin SR of template disks. Only support custom template.
+
+-> **Note:** `sr_for_full_disk_copy` is not allowed to be updated.
 - `static_mem_min` (Number) Statically-set (absolute) minimum memory (bytes), default same with `static_mem_max`. The least amount of memory this VM can boot with without crashing.
 
 ### Read-Only

--- a/examples/resources/xenserver_vm/resource.tf
+++ b/examples/resources/xenserver_vm/resource.tf
@@ -59,6 +59,23 @@ resource "xenserver_vm" "windows_vm" {
   }
 }
 
+# Create a Windows 11 VM that is copy from the custom template
+resource "xenserver_vm" "windows_vm_copy" {
+  name_label       = "Windows VM Copy From Custom Template"
+  template_name    = "Custom Windows 11 Template"
+  static_mem_max   = 4 * 1024 * 1024 * 1024
+  vcpus            = 4
+  cores_per_socket = 2
+  sr_for_full_disk_copy = data.xenserver_sr.sr.data_items[0].uuid
+
+  network_interface = [
+    {
+      device       = "0"
+      network_uuid = data.xenserver_network.network.data_items[0].uuid,
+    },
+  ]
+}
+
 # Create a Linux VM that is cloned from the custom template
 resource "xenserver_vm" "linux_vm" {
   name_label       = "Linux VM"


### PR DESCRIPTION
Test result:
```
ubuntu@ubuntu-server:~/code/terraform-provider-xenserver$ make testacc
if [ -z "/home/ubuntu/go/bin" ]; then echo "GOBIN is not set" && exit 1; fi
rm -f /home/ubuntu/go/bin/terraform-provider-xenserver
go mod tidy
go install .
md5sum /home/ubuntu/go/bin/terraform-provider-xenserver
dadcf21d7f58a845084291a25ec48321  /home/ubuntu/go/bin/terraform-provider-xenserver
source .env \
    && TF_ACC=1 go test -v  -timeout 60m ./xenserver/ \
    && TF_ACC=1 TEST_POOL=1 go test -v -run TestAccPoolResource -timeout 60m ./xenserver/
=== RUN   TestAccHostDataSource
--- PASS: TestAccHostDataSource (1.41s)
=== RUN   TestAccNetworkDataSource
--- PASS: TestAccNetworkDataSource (0.86s)
=== RUN   TestAccVlanResource
--- PASS: TestAccVlanResource (4.28s)
=== RUN   TestAccNICDataSource
--- PASS: TestAccNICDataSource (0.63s)
=== RUN   TestAccPIFConfigureResource
--- PASS: TestAccPIFConfigureResource (17.90s)
=== RUN   TestAccPifDataSource
--- PASS: TestAccPifDataSource (1.15s)
=== RUN   TestAccPoolResource
    pool_resource_test.go:108: Skipping TestAccPoolResource test due to TEST_POOL not set
--- SKIP: TestAccPoolResource (0.00s)
=== RUN   TestAccSnapshotResource
--- PASS: TestAccSnapshotResource (6.63s)
=== RUN   TestAccSRDataSource
--- PASS: TestAccSRDataSource (0.65s)
=== RUN   TestAccNFSResource
--- PASS: TestAccNFSResource (4.19s)
=== RUN   TestAccNFSISOResource
--- PASS: TestAccNFSISOResource (3.67s)
=== RUN   TestAccSRResourceLocal
--- PASS: TestAccSRResourceLocal (4.08s)
=== RUN   TestAccSRResourceShared
--- PASS: TestAccSRResourceShared (3.51s)
=== RUN   TestAccSMBResource
--- PASS: TestAccSMBResource (3.65s)
=== RUN   TestAccSMBISOResource
--- PASS: TestAccSMBISOResource (3.57s)
=== RUN   TestAccVDIResource
--- PASS: TestAccVDIResource (4.96s)
=== RUN   TestAccVMDataSource
--- PASS: TestAccVMDataSource (2.50s)
=== RUN   TestAccVMResource
--- PASS: TestAccVMResource (4.82s)
=== RUN   TestAccLinuxVMResource
--- PASS: TestAccLinuxVMResource (2.20s)
PASS
ok      terraform-provider-xenserver/xenserver  70.670s
```