### PR TITLE
CA-403474: Improve check before pool eject

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ export NFS_SERVER_PATH=<nfs-server-path>
 export SMB_SERVER_PATH=<smb-server-path>
 export SMB_SERVER_USERNAME=<smb-server-username>
 export SMB_SERVER_PASSWORD=<smb-server-password>
+export SUPPORTER_HOST=<supporter-ip>
+export SUPPORTER_USERNAME=<supporter-username>
+export SUPPORTER_PASSWORD=<supporter-password>
 ```
 
 Run `"make testacc"`. *Note:* Acceptance tests generate actual resources and frequently incur costs when run.

--- a/xenserver/pool_resource.go
+++ b/xenserver/pool_resource.go
@@ -61,13 +61,13 @@ func (r *poolResource) Configure(_ context.Context, req resource.ConfigureReques
 }
 
 func (r *poolResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	tflog.Debug(ctx, "---> Create Pool resource")
 	var plan poolResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	tflog.Debug(ctx, "Creating pool...")
 	poolParams := getPoolParams(plan)
 
 	poolRef, err := getPoolRef(r.session)
@@ -79,6 +79,7 @@ func (r *poolResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
+	tflog.Debug(ctx, "----> Start Pool join")
 	err = poolJoin(ctx, r.session, r.coordinatorConf, plan)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -88,6 +89,7 @@ func (r *poolResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
+	tflog.Debug(ctx, "----> Start Pool eject")
 	err = poolEject(ctx, r.session, plan)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -97,6 +99,7 @@ func (r *poolResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
+	tflog.Debug(ctx, "----> Start Pool setting")
 	err = setPool(r.session, poolRef, poolParams)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -166,6 +169,7 @@ func (r *poolResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 }
 
 func (r *poolResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	tflog.Debug(ctx, "---> Update Pool resource")
 	var plan, state poolResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -187,6 +191,7 @@ func (r *poolResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
+	tflog.Debug(ctx, "----> Start Pool join")
 	err = poolJoin(ctx, r.session, r.coordinatorConf, plan)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -196,6 +201,7 @@ func (r *poolResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
+	tflog.Debug(ctx, "----> Start Pool eject")
 	err = poolEject(ctx, r.session, plan)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -205,6 +211,7 @@ func (r *poolResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
+	tflog.Debug(ctx, "----> Start Pool setting")
 	err = setPool(r.session, poolRef, poolParams)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -237,26 +244,27 @@ func (r *poolResource) Update(ctx context.Context, req resource.UpdateRequest, r
 }
 
 func (r *poolResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	tflog.Debug(ctx, "---> Delete Pool resource")
 	var state poolResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	tflog.Debug(ctx, "Deleting pool...")
 	poolRef, err := xenapi.Pool.GetByUUID(r.session, state.UUID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to get pool ref", err.Error())
 		return
 	}
 
+	tflog.Debug(ctx, "----> Clean pool resource")
 	err = cleanupPoolResource(r.session, poolRef)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to cleanup pool resource", err.Error())
 		return
 	}
 
-	tflog.Debug(ctx, "Pool deleted")
+	tflog.Debug(ctx, "---> Pool deleted")
 }
 
 func (r *poolResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {


### PR DESCRIPTION
test result:
```
ubuntu@ubuntu-server:~/code/terraform-provider-xenserver$ make testacc
if [ -z "/home/ubuntu/go/bin" ]; then echo "GOBIN is not set" && exit 1; fi
rm -f /home/ubuntu/go/bin/terraform-provider-xenserver
go mod tidy
go install .
md5sum /home/ubuntu/go/bin/terraform-provider-xenserver
d21a70147473c4fc9c6a97ab6a3bed3e  /home/ubuntu/go/bin/terraform-provider-xenserver
source .env \
    && TF_ACC=1 go test -v  -timeout 60m ./xenserver/ \
    && TF_ACC=1 TEST_POOL=1 go test -v -run TestAccPoolResource -timeout 60m ./xenserver/
=== RUN   TestAccHostDataSource
--- PASS: TestAccHostDataSource (1.20s)
=== RUN   TestAccNetworkDataSource
--- PASS: TestAccNetworkDataSource (0.69s)
=== RUN   TestAccVlanResource
--- PASS: TestAccVlanResource (4.47s)
=== RUN   TestAccNICDataSource
--- PASS: TestAccNICDataSource (0.68s)
=== RUN   TestAccPIFConfigureResource
--- PASS: TestAccPIFConfigureResource (18.81s)
=== RUN   TestAccPifDataSource
--- PASS: TestAccPifDataSource (1.23s)
=== RUN   TestAccPoolResource
    pool_resource_test.go:108: Skipping TestAccPoolResource test due to TEST_POOL not set
--- SKIP: TestAccPoolResource (0.00s)
=== RUN   TestAccSnapshotResource
--- PASS: TestAccSnapshotResource (7.06s)
=== RUN   TestAccSRDataSource
--- PASS: TestAccSRDataSource (0.72s)
=== RUN   TestAccNFSResource
--- PASS: TestAccNFSResource (4.36s)
=== RUN   TestAccNFSISOResource
--- PASS: TestAccNFSISOResource (3.80s)
=== RUN   TestAccSRResourceLocal
--- PASS: TestAccSRResourceLocal (4.27s)
=== RUN   TestAccSRResourceShared
--- PASS: TestAccSRResourceShared (3.56s)
=== RUN   TestAccSMBResource
--- PASS: TestAccSMBResource (3.77s)
=== RUN   TestAccSMBISOResource
--- PASS: TestAccSMBISOResource (3.70s)
=== RUN   TestAccVDIResource
--- PASS: TestAccVDIResource (5.12s)
=== RUN   TestAccVMDataSource
--- PASS: TestAccVMDataSource (2.40s)
=== RUN   TestAccVMResource
--- PASS: TestAccVMResource (5.11s)
=== RUN   TestAccLinuxVMResource
--- PASS: TestAccLinuxVMResource (2.32s)
PASS
ok      terraform-provider-xenserver/xenserver  73.288s

ubuntu@ubuntu-server:~/code/terraform-provider-xenserver$ make testpool
if [ -z "/home/ubuntu/go/bin" ]; then echo "GOBIN is not set" && exit 1; fi
rm -f /home/ubuntu/go/bin/terraform-provider-xenserver
go mod tidy
go install .
md5sum /home/ubuntu/go/bin/terraform-provider-xenserver
f9bc8818e761c2304a5e1bd22c4e117d  /home/ubuntu/go/bin/terraform-provider-xenserver
source .env \
&& TF_ACC=1 TEST_POOL=1 go test -v -run TestAccPoolResource -timeout 60m ./xenserver/
=== RUN   TestAccPoolResource
--- PASS: TestAccPoolResource (47.14s)
``` 