### PR TITLE
CA-400243: Convert Ref to UUID in data source output

### DIFF
--- a/docs/data-sources/network.md
+++ b/docs/data-sources/network.md
@@ -40,8 +40,8 @@ output "network_output" {
 Read-Only:
 
 - `allowed_operations` (List of String) The list of the operations allowed in this state.
-- `assigned_ips` (Map of String) The IP addresses assigned to VIFs on networks that have active [xapi-managed](https://github.com/xapi-project/xen-api) DHCP.
-- `blobs` (Map of String) The binary blobs associated with this SR.
+- `assigned_ips` (Map of String) The IP addresses assigned to VIFs(UUID) on networks that have active [xapi-managed](https://github.com/xapi-project/xen-api) DHCP.
+- `blobs` (Map of String) The binary blobs(UUID) associated with this SR.
 - `bridge` (String) The name of the bridge corresponding to this network on the local host.
 - `current_operations` (Map of String) The links each of the running tasks using this object (by reference) to a current_operation enum which describes the nature of the task.
 - `default_locking_mode` (String) The network will use this value to determine the behavior of all VIFs where `locking_mode = default`.
@@ -50,8 +50,8 @@ Read-Only:
 - `name_description` (String) The human-readable description of the network.
 - `name_label` (String) The name of the network.
 - `other_config` (Map of String) The additional configuration.
-- `pifs` (List of String) The list of connected PIFs.
+- `pifs` (List of String) The list of connected PIFs(UUID).
 - `purpose` (List of String) Set of purposes for which the server will use this network.
 - `tags` (List of String) The user-specified tags for categorization purposes.
 - `uuid` (String) The UUID of the network.
-- `vifs` (List of String) The list of connected VIFs.
+- `vifs` (List of String) The list of connected VIFs(UUID).

--- a/docs/data-sources/pif.md
+++ b/docs/data-sources/pif.md
@@ -41,8 +41,8 @@ output "pif_data_out" {
 
 Read-Only:
 
-- `bond_master_of` (List of String) Indicates this PIF represents the results of a bond.
-- `bond_slave_of` (String) Indicates which bond this interface is part of.
+- `bond_master_of` (List of String) Indicates this PIF represents the results of a bond(UUID).
+- `bond_slave_of` (String) Indicates which bond(UUID) this interface is part of.
 - `capabilities` (List of String) Additional capabilities on the interface.
 - `currently_attached` (Boolean) True if this interface is online.
 - `device` (String) The machine-readable name of the physical interface (PIF). (For example, `"eth0"`)
@@ -63,15 +63,15 @@ Read-Only:
 - `netmask` (String) IP netmask.
 - `network` (String) The UUID of the virtual network to which this PIF is connected.
 - `other_config` (Map of String) Additional configuration.
-- `pci` (String) Link to underlying PCI device.
+- `pci` (String) Link to underlying PCI(UUID) device.
 - `physical` (Boolean) True if this represents a physical network interface.
 - `primary_address_type` (String) Which protocol should define the primary address of this interface.
 - `properties` (Map of String) Additional configuration properties for the interface.
-- `sriov_logical_pif_of` (List of String) Indicates which network_sriov this interface is the logical PIF of.
-- `sriov_physical_pif_of` (List of String) Indicates which network_sriov this interface is the physical PIF of.
-- `tunnel_access_pif_of` (List of String) Indicates to which tunnel this PIF gives access.
-- `tunnel_transport_pif_of` (List of String) Indicates to which tunnel this PIF provides transport.
+- `sriov_logical_pif_of` (List of String) Indicates which network_sriov(UUID) this interface is the logical PIF of.
+- `sriov_physical_pif_of` (List of String) Indicates which network_sriov(UUID) this interface is the physical PIF of.
+- `tunnel_access_pif_of` (List of String) Indicates to which tunnel(UUID) this PIF gives access.
+- `tunnel_transport_pif_of` (List of String) Indicates to which tunnel(UUID) this PIF provides transport.
 - `uuid` (String) The UUID of the storage repository.
 - `vlan` (Number) VLAN tag for all traffic passing through this interface.
-- `vlan_master_of` (String) Indicates which VLAN this interface receives untagged traffic from.
-- `vlan_slave_of` (List of String) Indicates which VLANs this interface transmits tagged traffic to.
+- `vlan_master_of` (String) Indicates which VLAN(UUID) this interface receives untagged traffic from.
+- `vlan_slave_of` (List of String) Indicates which VLANs(UUID) this interface transmits tagged traffic to.

--- a/docs/data-sources/sr.md
+++ b/docs/data-sources/sr.md
@@ -40,17 +40,17 @@ output "local_storage_output" {
 Read-Only:
 
 - `allowed_operations` (List of String) The list of the operations allowed in this state.
-- `blobs` (Map of String) The binary blobs associated with this SR.
+- `blobs` (Map of String) The binary blobs(UUID) associated with this SR.
 - `clustered` (Boolean) True if the SR is using aggregated local storage.
 - `content_type` (String) The type of the SR's content, if required (for example, "ISOs").
 - `current_operations` (Map of String) The links each of the running tasks using this object (by reference) to a current_operation enum which describes the nature of the task.
-- `introduced_by` (String) The disaster recovery task which introduced this SR.
+- `introduced_by` (String) The UUID of disaster recovery task which introduced this SR.
 - `is_tools_sr` (Boolean) True if this is the SR that contains the Tools ISO VDIs.
 - `local_cache_enabled` (Boolean) True if this SR is assigned to be the local cache for its host.
 - `name_description` (String) The human-readable description of the storage repository.
 - `name_label` (String) The name of the storage repository.
 - `other_config` (Map of String) The additional configuration.
-- `pbds` (List of String) Describes how particular hosts can see this storage repository.
+- `pbds` (List of String) The UUID list of PBDs. Describes how particular hosts can see this storage repository.
 - `physical_size` (Number) The total physical size of the storage repository (in bytes).
 - `physical_utilisation` (Number) The physical space currently utilized on this storage repository (in bytes).
 - `shared` (Boolean) True if this SR is (capable of being) shared between multiple hosts.
@@ -58,5 +58,5 @@ Read-Only:
 - `tags` (List of String) The user-specified tags for categorization purposes.
 - `type` (String) The type of the storage repository.
 - `uuid` (String) The UUID of the storage repository.
-- `vdis` (List of String) The all virtual disks known to this storage repository.
+- `vdis` (List of String) The UUID list of all virtual disks known to this storage repository.
 - `virtual_allocation` (Number) The sum of virtual_sizes of all VDIs in this storage repository (in bytes).

--- a/docs/data-sources/vm.md
+++ b/docs/data-sources/vm.md
@@ -43,20 +43,21 @@ Read-Only:
 - `actions_after_softreboot` (String) Action to take after soft reboot.
 - `affinity` (String) A host which the VM has some affinity for (or NULL). This is used as a hint to the start call when it decides where to run the VM. Resource constraints may cause the VM to be started elsewhere.
 - `allowed_operations` (List of String) The list of the operations allowed in this state.
-- `appliance` (String) The appliance to which this VM belongs.
-- `attached_pcis` (List of String) Currently passed-through PCI devices.
+- `appliance` (String) The appliance(UUID) to which this VM belongs.
+- `attached_pcis` (List of String) The UUID list of currently passed-through PCI devices.
 - `bios_strings` (Map of String) BIOS strings.
-- `blobs` (Map of String) Binary blobs associated with this VM.
+- `blobs` (Map of String) Binary blobs(UUID) associated with this VM.
 - `blocked_operations` (Map of String) List of operations which have been explicitly blocked and an error code.
-- `children` (List of String) List pointing to all the children of this VM.
-- `consoles` (List of String) Virtual console devices.
-- `crash_dumps` (List of String) Crash dumps associated with this VM.
+- `children` (List of String) UUID list pointing to all the children of this VM.
+- `consoles` (List of String) The UUID list of virtual console devices.
+- `crash_dumps` (List of String) The UUID list of crash dumps associated with this VM.
 - `current_operations` (Map of String) The links each of the running tasks using this object (by reference) to a current_operation enum which describes the nature of the task.
 - `domain_type` (String) The type of domain that will be created when the VM is started.
 - `domarch` (String) Domain architecture (if available, null string otherwise).
 - `domid` (Number) Domain ID (if available, -1 otherwise).
 - `generation_id` (String) Generation ID of the VM.
-- `guest_metrics` (String) Metrics associated with the running guest.
+- `groups` (List of String) The UUID list of VM groups associated with the VM.
+- `guest_metrics` (String) Metrics(UUID) associated with the running guest.
 - `ha_always_run` (Boolean) If true then the system will attempt to keep the VM running as much as possible.
 - `ha_restart_priority` (String) Has possible values: 'best-effort' meaning 'try to restart this VM if possible but don't consider the pool to be overcommitted if this is not possible'; 'restart' meaning 'this VM should be restarted'; '' meaning 'do not try to restart this VM'.
 - `hardware_platform_version` (Number) The host virtual hardware platform version the VM can run on.
@@ -78,20 +79,20 @@ Read-Only:
 - `memory_static_max` (Number) Statically-set (absolute) maximum (bytes). The value of this field at VM start time acts as a hard limit of the amount of memory a guest can use. New values only take effect on reboot.
 - `memory_static_min` (Number) Statically-set (absolute) mininum (bytes). The value of this field indicates the least amount of memory this VM can boot with without crashing.
 - `memory_target` (Number) Dynamically-set memory target (bytes). The value of this field indicates the current target for memory available to this VM.
-- `metrics` (String) Metrics associated with this VM.
+- `metrics` (String) Metrics(UUID) associated with this VM.
 - `name_description` (String) The description of the virtual machine.
 - `name_label` (String) The name of the virtual machine.
 - `nvram` (Map of String) Initial value for guest NVRAM (containing UEFI variables, and so on). Cannot be changed while the VM is running.
 - `order` (Number) The point in the startup or shutdown sequence at which this VM will be started.
 - `other_config` (Map of String) Additional configuration.
-- `parent` (String) Ref pointing to the parent of this VM.
+- `parent` (String) UUID pointing to the parent of this VM.
 - `pci_bus` (String) PCI bus path for pass-through devices.
 - `pending_guidances` (List of String) The set of pending mandatory guidances after applying updates, which must be applied, as otherwise there may be, for example, VM failures.
 - `pending_guidances_full` (List of String) The set of pending full guidances after applying updates, which a user should follow to make some updates, for example, specific hardware drivers or CPU features, fully effective, but the 'average user' doesn't need to.
 - `pending_guidances_recommended` (List of String) The set of pending recommended guidances after applying updates, which most users should follow to make the updates effective, but if not followed, will not cause a failure.
 - `platform` (Map of String) Platform-specific configuration.
 - `power_state` (String) The current power state of the virtual machine.
-- `protection_policy` (String) Ref pointing to a protection policy for this VM.
+- `protection_policy` (String) UUID pointing to a protection policy for this VM.
 - `pv_args` (String) Kernel command-line arguments
 - `pv_bootloader` (String) Name of or path to bootloader.
 - `pv_bootloader_args` (String) Miscellaneous arguments for the bootloader.
@@ -101,29 +102,29 @@ Read-Only:
 - `recommendations` (String) An XML specification of recommended values and ranges for properties of this VM.
 - `reference_label` (String) Textual reference to the template used to create a VM. This can be used by clients in need of an immutable reference to the template since the latter's uuid and name_label may change, for example, after a package installation or upgrade.
 - `requires_reboot` (Boolean) Indicates whether a VM requires a reboot in order to update its configuration, for example, its memory allocation.
-- `resident_on` (String) The host the VM is currently resident on.
-- `scheduled_to_be_resident_on` (String) The host on which the VM is due to be started/resumed/migrated. This acts as a memory reservation indicator.
+- `resident_on` (String) The host(UUID) the VM is currently resident on.
+- `scheduled_to_be_resident_on` (String) The host(UUID) on which the VM is due to be started/resumed/migrated. This acts as a memory reservation indicator.
 - `shutdown_delay` (Number) The delay to wait before proceeding to the next order in the shutdown sequence (seconds).
 - `snapshot_info` (Map of String) Human-readable information concerning this snapshot.
 - `snapshot_metadata` (String) Metadata concerning this snapshot.
-- `snapshot_of` (String) Ref pointing to the VM this snapshot is of.
-- `snapshot_schedule` (String) Ref pointing to a snapshot schedule for this VM.
+- `snapshot_of` (String) UUID pointing to the VM this snapshot is of.
+- `snapshot_schedule` (String) UUID pointing to a snapshot schedule for this VM.
 - `snapshot_time` (String) Date/time when this snapshot was created.
-- `snapshots` (List of String) List pointing to all the VM snapshots.
+- `snapshots` (List of String) UUID list pointing to all the VM snapshots.
 - `start_delay` (Number) The delay to wait before proceeding to the next order in the startup sequence (seconds).
-- `suspend_sr` (String) The SR on which a suspend image is stored.
-- `suspend_vdi` (String) The VDI that a suspend image is stored on. Only has meaning if VM is currently suspended.
+- `suspend_sr` (String) The SR(UUID) on which a suspend image is stored.
+- `suspend_vdi` (String) The VDI(UUID) that a suspend image is stored on. Only has meaning if VM is currently suspended.
 - `tags` (List of String) User-specified tags for categorization purposes.
 - `transportable_snapshot_id` (String) Transportable ID of the snapshot VM.
 - `user_version` (Number) Creators of VMs and templates may store version information here.
 - `uuid` (String) The UUID of the virtual machine.
-- `vbds` (List of String) Virtual block devices.
+- `vbds` (List of String) The UUID list of virtual block devices.
 - `vcpus_at_startup` (Number) Boot number of VCPUs.
 - `vcpus_max` (Number) Max number of VCPUs.
 - `vcpus_params` (Map of String) Configuration parameters for the selected VCPU policy.
 - `version` (Number) The number of times this VM has been recovered.
-- `vgpus` (List of String) Virtual GPUs.
-- `vifs` (List of String) Virtual network interfaces.
-- `vtpms` (List of String) Virtual TPMs.
-- `vusbs` (List of String) Virtual USB devices.
+- `vgpus` (List of String) The UUID list of virtual GPUs.
+- `vifs` (List of String) The UUID list of virtual network interfaces.
+- `vtpms` (List of String) The UUID list of virtual TPMs.
+- `vusbs` (List of String) The UUID list of virtual USB devices.
 - `xenstore_data` (Map of String) Data to be inserted into the xenstore tree (/local/domain/<domid>/vm-data) after the VM is created.

--- a/examples/test-data-sources/main.tf
+++ b/examples/test-data-sources/main.tf
@@ -1,0 +1,55 @@
+locals {
+  env_vars = { for tuple in regexall("export\\s*(\\S*)\\s*=\\s*(\\S*)\\s*", file("../../.env")) : tuple[0] => tuple[1] }
+}
+
+terraform {
+  required_providers {
+    xenserver = {
+      source = "xenserver/xenserver"
+    }
+  }
+}
+
+provider "xenserver" {
+  host     = local.env_vars["XENSERVER_HOST"]
+  username = local.env_vars["XENSERVER_USERNAME"]
+  password = local.env_vars["XENSERVER_PASSWORD"]
+}
+
+data "xenserver_host" "host" {}
+
+output "host_output" {
+  value = data.xenserver_host.host.data_items
+}
+
+data "xenserver_network" "network" {}
+
+output "network_output" {
+  value = data.xenserver_network.network.data_items
+}
+
+data "xenserver_nic" "nic" {}
+
+output "nic_output" {
+  value = data.xenserver_nic.nic.data_items
+}
+
+data "xenserver_pif" "pif" {}
+
+output "pif_data_out" {
+  value = data.xenserver_pif.pif.data_items
+}
+
+data "xenserver_sr" "sr" {}
+
+output "local_storage_output" {
+  value = data.xenserver_sr.sr.data_items
+}
+
+data "xenserver_vm" "vm_data" {
+    name_label = "TestVM"
+}
+
+output "vm_data_out" {
+  value = data.xenserver_vm.vm_data.data_items
+}

--- a/examples/test-resources/main.tf
+++ b/examples/test-resources/main.tf
@@ -16,38 +16,14 @@ provider "xenserver" {
   password = local.env_vars["XENSERVER_PASSWORD"]
 }
 
-data "xenserver_vm" "vm_data" {
-}
-
-output "vm_data_out" {
-  value = data.xenserver_vm.vm_data.data_items
-}
-
-data "xenserver_pif" "pif" {
-  device     = "eth0"
-  management = true
-}
-
-output "pif_data_out" {
-  value = data.xenserver_pif.pif.data_items
-}
-
 data "xenserver_sr" "sr" {
   name_label = "Local storage"
-}
-
-output "local_storage_output" {
-  value = data.xenserver_sr.sr.data_items
 }
 
 resource "xenserver_sr" "local" {
   name_label = "Test Local SR"
   type       = "dummy"
   shared     = false
-}
-
-output "sr_local_out" {
-  value = xenserver_sr.local
 }
 
 resource "xenserver_sr_smb" "smb_test" {
@@ -124,20 +100,8 @@ output "vdi_out2" {
   value = xenserver_vdi.vdi2
 }
 
-data "xenserver_network" "network" {
-  name_label = "Pool-wide network associated with eth0"
-}
-
-output "network_output" {
-  value = data.xenserver_network.network.data_items
-}
-
 data "xenserver_nic" "nic" {
   network_type = "vlan"
-}
-
-output "nic_output" {
-  value = data.xenserver_nic.nic.data_items
 }
 
 resource "xenserver_network_vlan" "vlan" {

--- a/xenserver/host_utils.go
+++ b/xenserver/host_utils.go
@@ -67,15 +67,9 @@ func updateHostRecordData(ctx context.Context, session *xenapi.Session, record x
 	data.NameDescription = types.StringValue(record.NameDescription)
 	data.Hostname = types.StringValue(record.Hostname)
 	data.Address = types.StringValue(record.Address)
-	residentVMs := []string{}
-	for _, vmRef := range record.ResidentVMs {
-		if vmRef != record.ControlDomain {
-			vmUUID, err := xenapi.VM.GetUUID(session, vmRef)
-			if err != nil {
-				return errors.New(err.Error())
-			}
-			residentVMs = append(residentVMs, vmUUID)
-		}
+	residentVMs, err := getVMUUIDs(session, record.ResidentVMs, record.ControlDomain)
+	if err != nil {
+		return err
 	}
 	var diags diag.Diagnostics
 	data.ResidentVMs, diags = types.ListValueFrom(ctx, types.StringType, residentVMs)

--- a/xenserver/network_data_source.go
+++ b/xenserver/network_data_source.go
@@ -75,12 +75,12 @@ func (d *networkDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 							ElementType:         types.StringType,
 						},
 						"vifs": schema.ListAttribute{
-							MarkdownDescription: "The list of connected VIFs.",
+							MarkdownDescription: "The list of connected VIFs(UUID).",
 							Computed:            true,
 							ElementType:         types.StringType,
 						},
 						"pifs": schema.ListAttribute{
-							MarkdownDescription: "The list of connected PIFs.",
+							MarkdownDescription: "The list of connected PIFs(UUID).",
 							Computed:            true,
 							ElementType:         types.StringType,
 						},
@@ -102,7 +102,7 @@ func (d *networkDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 							Computed:            true,
 						},
 						"blobs": schema.MapAttribute{
-							MarkdownDescription: "The binary blobs associated with this SR.",
+							MarkdownDescription: "The binary blobs(UUID) associated with this SR.",
 							Computed:            true,
 							ElementType:         types.StringType,
 						},
@@ -116,7 +116,7 @@ func (d *networkDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 							Computed:            true,
 						},
 						"assigned_ips": schema.MapAttribute{
-							MarkdownDescription: "The IP addresses assigned to VIFs on networks that have active [xapi-managed](https://github.com/xapi-project/xen-api) DHCP.",
+							MarkdownDescription: "The IP addresses assigned to VIFs(UUID) on networks that have active [xapi-managed](https://github.com/xapi-project/xen-api) DHCP.",
 							Computed:            true,
 							ElementType:         types.StringType,
 						},
@@ -177,7 +177,7 @@ func (d *networkDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		}
 
 		var networkData networkRecordData
-		err = updateNetworkRecordData(ctx, networkRecord, &networkData)
+		err = updateNetworkRecordData(ctx, d.session, networkRecord, &networkData)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Unable to update network record data",

--- a/xenserver/pif_data_source.go
+++ b/xenserver/pif_data_source.go
@@ -96,20 +96,20 @@ func pifDataSchema() map[string]schema.Attribute {
 			Computed:            true,
 		},
 		"bond_slave_of": schema.StringAttribute{
-			MarkdownDescription: "Indicates which bond this interface is part of.",
+			MarkdownDescription: "Indicates which bond(UUID) this interface is part of.",
 			Computed:            true,
 		},
 		"bond_master_of": schema.ListAttribute{
-			MarkdownDescription: "Indicates this PIF represents the results of a bond.",
+			MarkdownDescription: "Indicates this PIF represents the results of a bond(UUID).",
 			Computed:            true,
 			ElementType:         types.StringType,
 		},
 		"vlan_master_of": schema.StringAttribute{
-			MarkdownDescription: "Indicates which VLAN this interface receives untagged traffic from.",
+			MarkdownDescription: "Indicates which VLAN(UUID) this interface receives untagged traffic from.",
 			Computed:            true,
 		},
 		"vlan_slave_of": schema.ListAttribute{
-			MarkdownDescription: "Indicates which VLANs this interface transmits tagged traffic to.",
+			MarkdownDescription: "Indicates which VLANs(UUID) this interface transmits tagged traffic to.",
 			Computed:            true,
 			ElementType:         types.StringType,
 		},
@@ -123,12 +123,12 @@ func pifDataSchema() map[string]schema.Attribute {
 			Computed:            true,
 		},
 		"tunnel_access_pif_of": schema.ListAttribute{
-			MarkdownDescription: "Indicates to which tunnel this PIF gives access.",
+			MarkdownDescription: "Indicates to which tunnel(UUID) this PIF gives access.",
 			Computed:            true,
 			ElementType:         types.StringType,
 		},
 		"tunnel_transport_pif_of": schema.ListAttribute{
-			MarkdownDescription: "Indicates to which tunnel this PIF provides transport.",
+			MarkdownDescription: "Indicates to which tunnel(UUID) this PIF provides transport.",
 			Computed:            true,
 			ElementType:         types.StringType,
 		},
@@ -168,17 +168,17 @@ func pifDataSchema() map[string]schema.Attribute {
 			Computed:            true,
 		},
 		"sriov_physical_pif_of": schema.ListAttribute{
-			MarkdownDescription: "Indicates which network_sriov this interface is the physical PIF of.",
+			MarkdownDescription: "Indicates which network_sriov(UUID) this interface is the physical PIF of.",
 			Computed:            true,
 			ElementType:         types.StringType,
 		},
 		"sriov_logical_pif_of": schema.ListAttribute{
-			MarkdownDescription: "Indicates which network_sriov this interface is the logical PIF of.",
+			MarkdownDescription: "Indicates which network_sriov(UUID) this interface is the logical PIF of.",
 			Computed:            true,
 			ElementType:         types.StringType,
 		},
 		"pci": schema.StringAttribute{
-			MarkdownDescription: "Link to underlying PCI device.",
+			MarkdownDescription: "Link to underlying PCI(UUID) device.",
 			Computed:            true,
 		},
 	}

--- a/xenserver/pool_utils.go
+++ b/xenserver/pool_utils.go
@@ -178,9 +178,9 @@ func poolJoin(ctx context.Context, coordinatorSession *xenapi.Session, coordinat
 			return errors.New("unable to join supporter host " + supporter.Host.ValueString() + ", it's not a standalone host")
 		}
 		supporterRef := hostRefs[0]
-		supporterUUID, err := xenapi.Host.GetUUID(supporterSession, supporterRef)
+		supporterUUID, err := getUUIDFromHostRef(supporterSession, supporterRef)
 		if err != nil {
-			return errors.New(err.Error() + ". \n\nunable to get supporter host UUID with host: " + supporter.Host.ValueString())
+			return errors.New(err.Error() + ". \n\nsupporter host is: " + supporter.Host.ValueString())
 		}
 
 		// check if the host is in eject_supporters, return error if it is
@@ -250,9 +250,9 @@ func poolEject(ctx context.Context, session *xenapi.Session, plan poolResourceMo
 	}
 	beforeEjectHosts := make(map[string]xenapi.HostRef)
 	for _, ref := range beforeEjectHostRefs {
-		uuid, err := xenapi.Host.GetUUID(session, ref)
+		uuid, err := getUUIDFromHostRef(session, ref)
 		if err != nil {
-			return errors.New("unable to get the origin host uuid in pool. " + err.Error())
+			return err
 		}
 		beforeEjectHosts[uuid] = ref
 	}
@@ -285,9 +285,9 @@ func getCoordinatorRef(session *xenapi.Session) (xenapi.HostRef, string, error) 
 	if err != nil {
 		return coordinatorRef, coordinatorUUID, errors.New("unable to get pool master. " + err.Error())
 	}
-	coordinatorUUID, err = xenapi.Host.GetUUID(session, coordinatorRef)
+	coordinatorUUID, err = getUUIDFromHostRef(session, coordinatorRef)
 	if err != nil {
-		return coordinatorRef, coordinatorUUID, errors.New("unable to get host UUID. " + err.Error())
+		return coordinatorRef, coordinatorUUID, err
 	}
 	return coordinatorRef, coordinatorUUID, nil
 }
@@ -425,7 +425,7 @@ func updatePoolResourceModelComputed(session *xenapi.Session, record xenapi.Pool
 
 	data.DefaultSRUUID = types.StringValue("")
 	if string(record.DefaultSR) != "OpaqueRef:NULL" {
-		srUUID, err := xenapi.SR.GetUUID(session, record.DefaultSR)
+		srUUID, err := getUUIDFromSRRef(session, record.DefaultSR)
 		if err == nil {
 			data.DefaultSRUUID = types.StringValue(srUUID)
 		}

--- a/xenserver/snapshot_utils.go
+++ b/xenserver/snapshot_utils.go
@@ -22,9 +22,9 @@ type snapshotResourceModel struct {
 
 func updateSnapshotResourceModel(ctx context.Context, session *xenapi.Session, record xenapi.VMRecord, data *snapshotResourceModel) error {
 	data.NameLabel = types.StringValue(record.NameLabel)
-	vmUUID, err := xenapi.VM.GetUUID(session, record.SnapshotOf)
+	vmUUID, err := getUUIDFromVMRef(session, record.SnapshotOf)
 	if err != nil {
-		return errors.New(err.Error())
+		return err
 	}
 	data.VM = types.StringValue(vmUUID)
 
@@ -75,9 +75,9 @@ func updateSnapshotResourceModelComputed(ctx context.Context, session *xenapi.Se
 			if err != nil {
 				return errors.New(err.Error())
 			}
-			srUUID, err := xenapi.SR.GetUUID(session, vdiRecord.SR)
+			srUUID, err := getUUIDFromSRRef(session, vdiRecord.SR)
 			if err != nil {
-				return errors.New(err.Error())
+				return err
 			}
 			otherConfig, diags := types.MapValueFrom(ctx, types.StringType, vdiRecord.OtherConfig)
 			if diags.HasError() {

--- a/xenserver/sr_data_source.go
+++ b/xenserver/sr_data_source.go
@@ -75,12 +75,12 @@ func (d *srDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, res
 							ElementType:         types.StringType,
 						},
 						"vdis": schema.ListAttribute{
-							MarkdownDescription: "The all virtual disks known to this storage repository.",
+							MarkdownDescription: "The UUID list of all virtual disks known to this storage repository.",
 							Computed:            true,
 							ElementType:         types.StringType,
 						},
 						"pbds": schema.ListAttribute{
-							MarkdownDescription: "Describes how particular hosts can see this storage repository.",
+							MarkdownDescription: "The UUID list of PBDs. Describes how particular hosts can see this storage repository.",
 							Computed:            true,
 							ElementType:         types.StringType,
 						},
@@ -124,7 +124,7 @@ func (d *srDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, res
 							ElementType:         types.StringType,
 						},
 						"blobs": schema.MapAttribute{
-							MarkdownDescription: "The binary blobs associated with this SR.",
+							MarkdownDescription: "The binary blobs(UUID) associated with this SR.",
 							Computed:            true,
 							ElementType:         types.StringType,
 						},
@@ -133,7 +133,7 @@ func (d *srDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, res
 							Computed:            true,
 						},
 						"introduced_by": schema.StringAttribute{
-							MarkdownDescription: "The disaster recovery task which introduced this SR.",
+							MarkdownDescription: "The UUID of disaster recovery task which introduced this SR.",
 							Computed:            true,
 						},
 						"clustered": schema.BoolAttribute{
@@ -194,7 +194,7 @@ func (d *srDataSource) Read(ctx context.Context, req datasource.ReadRequest, res
 		}
 
 		var srData srRecordData
-		err = updateSRRecordData(ctx, srRecord, &srData)
+		err = updateSRRecordData(ctx, d.session, srRecord, &srData)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Unable to update SR record data",

--- a/xenserver/uuid_utils.go
+++ b/xenserver/uuid_utils.go
@@ -1,0 +1,570 @@
+package xenserver
+
+import (
+	"errors"
+
+	"xenapi"
+)
+
+func getBlobUUIDsMap(session *xenapi.Session, oldMap map[string]xenapi.BlobRef) (map[string]string, error) {
+	// map[string]BlobRef to map[string]string
+	newMap := make(map[string]string)
+	for key, ref := range oldMap {
+		uuid, err := getUUIDFromBlobRef(session, ref)
+		if err != nil {
+			return newMap, err
+		}
+		newMap[key] = uuid
+	}
+	return newMap, nil
+}
+
+func getUUIDFromBlobRef(session *xenapi.Session, ref xenapi.BlobRef) (string, error) {
+	if string(ref) != "" && string(ref) != "OpaqueRef:NULL" {
+		uuid, err := xenapi.Blob.GetUUID(session, ref)
+		if err != nil {
+			return uuid, errors.New("unable to get blob UUID. " + err.Error())
+		}
+		return uuid, nil
+	}
+	return "", nil
+}
+
+func getBondUUIDs(session *xenapi.Session, refs []xenapi.BondRef) ([]string, error) {
+	uuids := []string{}
+	for _, ref := range refs {
+		uuid, err := getUUIDFromBondRef(session, ref)
+		if err != nil {
+			return uuids, err
+		}
+		if uuid != "" {
+			uuids = append(uuids, uuid)
+		}
+	}
+	return uuids, nil
+}
+
+func getUUIDFromBondRef(session *xenapi.Session, ref xenapi.BondRef) (string, error) {
+	if string(ref) != "" && string(ref) != "OpaqueRef:NULL" {
+		uuid, err := xenapi.Bond.GetUUID(session, ref)
+		if err != nil {
+			return uuid, errors.New("unable to get bond UUID. " + err.Error())
+		}
+		return uuid, nil
+	}
+	return "", nil
+}
+
+func getConsoleUUIDs(session *xenapi.Session, refs []xenapi.ConsoleRef) ([]string, error) {
+	uuids := []string{}
+	for _, ref := range refs {
+		uuid, err := getUUIDFromConsoleRef(session, ref)
+		if err != nil {
+			return uuids, err
+		}
+		if uuid != "" {
+			uuids = append(uuids, uuid)
+		}
+	}
+	return uuids, nil
+}
+
+func getUUIDFromConsoleRef(session *xenapi.Session, ref xenapi.ConsoleRef) (string, error) {
+	if string(ref) != "" && string(ref) != "OpaqueRef:NULL" {
+		uuid, err := xenapi.Console.GetUUID(session, ref)
+		if err != nil {
+			return uuid, errors.New("unable to get console UUID. " + err.Error())
+		}
+		return uuid, nil
+	}
+	return "", nil
+}
+
+func getCrashdumpUUIDs(session *xenapi.Session, refs []xenapi.CrashdumpRef) ([]string, error) {
+	uuids := []string{}
+	for _, ref := range refs {
+		uuid, err := getUUIDFromCrashdumpRef(session, ref)
+		if err != nil {
+			return uuids, err
+		}
+		if uuid != "" {
+			uuids = append(uuids, uuid)
+		}
+	}
+	return uuids, nil
+}
+
+func getUUIDFromCrashdumpRef(session *xenapi.Session, ref xenapi.CrashdumpRef) (string, error) {
+	if string(ref) != "" && string(ref) != "OpaqueRef:NULL" {
+		uuid, err := xenapi.Crashdump.GetUUID(session, ref)
+		if err != nil {
+			return uuid, errors.New("unable to get crash dump UUID. " + err.Error())
+		}
+		return uuid, nil
+	}
+	return "", nil
+}
+
+func getUUIDFromDRTaskRef(session *xenapi.Session, ref xenapi.DRTaskRef) (string, error) {
+	if string(ref) != "" && string(ref) != "OpaqueRef:NULL" {
+		uuid, err := xenapi.DRTask.GetUUID(session, ref)
+		if err != nil {
+			return uuid, errors.New("unable to get DR task UUID. " + err.Error())
+		}
+		return uuid, nil
+	}
+	return "", nil
+}
+
+func getUUIDFromHostRef(session *xenapi.Session, ref xenapi.HostRef) (string, error) {
+	if string(ref) != "" && string(ref) != "OpaqueRef:NULL" {
+		uuid, err := xenapi.Host.GetUUID(session, ref)
+		if err != nil {
+			return uuid, errors.New("unable to get host UUID. " + err.Error())
+		}
+		return uuid, nil
+	}
+	return "", nil
+}
+
+func getUUIDFromNetworkRef(session *xenapi.Session, ref xenapi.NetworkRef) (string, error) {
+	if string(ref) != "" && string(ref) != "OpaqueRef:NULL" {
+		uuid, err := xenapi.Network.GetUUID(session, ref)
+		if err != nil {
+			return uuid, errors.New("unable to get network UUID. " + err.Error())
+		}
+		return uuid, nil
+	}
+	return "", nil
+}
+
+func getNetworkSriovUUIDs(session *xenapi.Session, refs []xenapi.NetworkSriovRef) ([]string, error) {
+	uuids := []string{}
+	for _, ref := range refs {
+		uuid, err := getUUIDFromNetworkSriovRef(session, ref)
+		if err != nil {
+			return uuids, err
+		}
+		if uuid != "" {
+			uuids = append(uuids, uuid)
+		}
+	}
+	return uuids, nil
+}
+
+func getUUIDFromNetworkSriovRef(session *xenapi.Session, ref xenapi.NetworkSriovRef) (string, error) {
+	if string(ref) != "" && string(ref) != "OpaqueRef:NULL" {
+		uuid, err := xenapi.NetworkSriov.GetUUID(session, ref)
+		if err != nil {
+			return uuid, errors.New("unable to get network sr-iov UUID. " + err.Error())
+		}
+		return uuid, nil
+	}
+	return "", nil
+}
+
+func getPBDUUIDs(session *xenapi.Session, refs []xenapi.PBDRef) ([]string, error) {
+	uuids := []string{}
+	for _, ref := range refs {
+		uuid, err := getUUIDFromPBDRef(session, ref)
+		if err != nil {
+			return uuids, err
+		}
+		if uuid != "" {
+			uuids = append(uuids, uuid)
+		}
+	}
+	return uuids, nil
+}
+
+func getUUIDFromPBDRef(session *xenapi.Session, ref xenapi.PBDRef) (string, error) {
+	if string(ref) != "" && string(ref) != "OpaqueRef:NULL" {
+		uuid, err := xenapi.PBD.GetUUID(session, ref)
+		if err != nil {
+			return uuid, errors.New("unable to get PBD UUID. " + err.Error())
+		}
+		return uuid, nil
+	}
+	return "", nil
+}
+
+func getPCIUUIDs(session *xenapi.Session, refs []xenapi.PCIRef) ([]string, error) {
+	uuids := []string{}
+	for _, ref := range refs {
+		uuid, err := getUUIDFromPCIRef(session, ref)
+		if err != nil {
+			return uuids, err
+		}
+		if uuid != "" {
+			uuids = append(uuids, uuid)
+		}
+	}
+	return uuids, nil
+}
+
+func getUUIDFromPCIRef(session *xenapi.Session, ref xenapi.PCIRef) (string, error) {
+	if string(ref) != "" && string(ref) != "OpaqueRef:NULL" {
+		uuid, err := xenapi.PCI.GetUUID(session, ref)
+		if err != nil {
+			return uuid, errors.New("unable to get PCI UUID. " + err.Error())
+		}
+		return uuid, nil
+	}
+	return "", nil
+}
+
+func getPIFUUIDs(session *xenapi.Session, refs []xenapi.PIFRef) ([]string, error) {
+	uuids := []string{}
+	for _, ref := range refs {
+		uuid, err := getUUIDFromPIFRef(session, ref)
+		if err != nil {
+			return uuids, err
+		}
+		if uuid != "" {
+			uuids = append(uuids, uuid)
+		}
+	}
+	return uuids, nil
+}
+
+func getUUIDFromPIFRef(session *xenapi.Session, ref xenapi.PIFRef) (string, error) {
+	if string(ref) != "" && string(ref) != "OpaqueRef:NULL" {
+		uuid, err := xenapi.PIF.GetUUID(session, ref)
+		if err != nil {
+			return uuid, errors.New("unable to get PIF UUID. " + err.Error())
+		}
+		return uuid, nil
+	}
+	return "", nil
+}
+
+func getUUIDFromSRRef(session *xenapi.Session, ref xenapi.SRRef) (string, error) {
+	if string(ref) != "" && string(ref) != "OpaqueRef:NULL" {
+		uuid, err := xenapi.SR.GetUUID(session, ref)
+		if err != nil {
+			return uuid, errors.New("unable to get SR UUID. " + err.Error())
+		}
+		return uuid, nil
+	}
+	return "", nil
+}
+
+func getTunnelUUIDs(session *xenapi.Session, refs []xenapi.TunnelRef) ([]string, error) {
+	uuids := []string{}
+	for _, ref := range refs {
+		uuid, err := getUUIDFromTunnelRef(session, ref)
+		if err != nil {
+			return uuids, err
+		}
+		if uuid != "" {
+			uuids = append(uuids, uuid)
+		}
+	}
+	return uuids, nil
+}
+
+func getUUIDFromTunnelRef(session *xenapi.Session, ref xenapi.TunnelRef) (string, error) {
+	if string(ref) != "" && string(ref) != "OpaqueRef:NULL" {
+		uuid, err := xenapi.Tunnel.GetUUID(session, ref)
+		if err != nil {
+			return uuid, errors.New("unable to get tunnel UUID. " + err.Error())
+		}
+		return uuid, nil
+	}
+	return "", nil
+}
+
+func getVBDUUIDs(session *xenapi.Session, refs []xenapi.VBDRef) ([]string, error) {
+	uuids := []string{}
+	for _, ref := range refs {
+		uuid, err := getUUIDFromVBDRef(session, ref)
+		if err != nil {
+			return uuids, err
+		}
+		if uuid != "" {
+			uuids = append(uuids, uuid)
+		}
+	}
+	return uuids, nil
+}
+
+func getUUIDFromVBDRef(session *xenapi.Session, ref xenapi.VBDRef) (string, error) {
+	if string(ref) != "" && string(ref) != "OpaqueRef:NULL" {
+		uuid, err := xenapi.VBD.GetUUID(session, ref)
+		if err != nil {
+			return uuid, errors.New("unable to get VBD UUID. " + err.Error())
+		}
+		return uuid, nil
+	}
+	return "", nil
+}
+
+func getVDIUUIDs(session *xenapi.Session, refs []xenapi.VDIRef) ([]string, error) {
+	uuids := []string{}
+	for _, ref := range refs {
+		uuid, err := getUUIDFromVDIRef(session, ref)
+		if err != nil {
+			return uuids, err
+		}
+		if uuid != "" {
+			uuids = append(uuids, uuid)
+		}
+	}
+	return uuids, nil
+}
+
+func getUUIDFromVDIRef(session *xenapi.Session, ref xenapi.VDIRef) (string, error) {
+	if string(ref) != "" && string(ref) != "OpaqueRef:NULL" {
+		uuid, err := xenapi.VDI.GetUUID(session, ref)
+		if err != nil {
+			return uuid, errors.New("unable to get VDI UUID. " + err.Error())
+		}
+		return uuid, nil
+	}
+	return "", nil
+}
+
+func getVGPUUUIDs(session *xenapi.Session, refs []xenapi.VGPURef) ([]string, error) {
+	uuids := []string{}
+	for _, ref := range refs {
+		uuid, err := getUUIDFromVGPURef(session, ref)
+		if err != nil {
+			return uuids, err
+		}
+		if uuid != "" {
+			uuids = append(uuids, uuid)
+		}
+	}
+	return uuids, nil
+}
+
+func getUUIDFromVGPURef(session *xenapi.Session, ref xenapi.VGPURef) (string, error) {
+	if string(ref) != "" && string(ref) != "OpaqueRef:NULL" {
+		uuid, err := xenapi.VGPU.GetUUID(session, ref)
+		if err != nil {
+			return uuid, errors.New("unable to get vGPU UUID. " + err.Error())
+		}
+		return uuid, nil
+	}
+	return "", nil
+}
+
+func getVIFUUIDsMap(session *xenapi.Session, oldMap map[xenapi.VIFRef]string) (map[string]string, error) {
+	// map[VIFRef]string to map[string]string
+	newMap := make(map[string]string)
+	for ref, value := range oldMap {
+		uuid, err := getUUIDFromVIFRef(session, ref)
+		if err != nil {
+			return newMap, err
+		}
+		newMap[uuid] = value
+	}
+	return newMap, nil
+}
+
+func getVIFUUIDs(session *xenapi.Session, refs []xenapi.VIFRef) ([]string, error) {
+	uuids := []string{}
+	for _, ref := range refs {
+		uuid, err := getUUIDFromVIFRef(session, ref)
+		if err != nil {
+			return uuids, err
+		}
+		if uuid != "" {
+			uuids = append(uuids, uuid)
+		}
+	}
+	return uuids, nil
+}
+
+func getUUIDFromVIFRef(session *xenapi.Session, ref xenapi.VIFRef) (string, error) {
+	if string(ref) != "" && string(ref) != "OpaqueRef:NULL" {
+		uuid, err := xenapi.VIF.GetUUID(session, ref)
+		if err != nil {
+			return uuid, errors.New("unable to get VIF UUID. " + err.Error())
+		}
+		return uuid, nil
+	}
+	return "", nil
+}
+
+func getVLANUUIDs(session *xenapi.Session, refs []xenapi.VLANRef) ([]string, error) {
+	uuids := []string{}
+	for _, ref := range refs {
+		uuid, err := getUUIDFromVLANRef(session, ref)
+		if err != nil {
+			return uuids, err
+		}
+		if uuid != "" {
+			uuids = append(uuids, uuid)
+		}
+	}
+	return uuids, nil
+}
+
+func getUUIDFromVLANRef(session *xenapi.Session, ref xenapi.VLANRef) (string, error) {
+	if string(ref) != "" && string(ref) != "OpaqueRef:NULL" {
+		uuid, err := xenapi.VLAN.GetUUID(session, ref)
+		if err != nil {
+			return uuid, errors.New("unable to get vlan UUID. " + err.Error())
+		}
+		return uuid, nil
+	}
+	return "", nil
+}
+
+func getVMUUIDs(session *xenapi.Session, refs []xenapi.VMRef, excludeRef xenapi.VMRef) ([]string, error) {
+	uuids := []string{}
+	for _, ref := range refs {
+		if ref != excludeRef {
+			uuid, err := getUUIDFromVMRef(session, ref)
+			if err != nil {
+				return uuids, err
+			}
+			if uuid != "" {
+				uuids = append(uuids, uuid)
+			}
+		}
+	}
+	return uuids, nil
+}
+
+func getUUIDFromVMRef(session *xenapi.Session, ref xenapi.VMRef) (string, error) {
+	if string(ref) != "" && string(ref) != "OpaqueRef:NULL" {
+		uuid, err := xenapi.VM.GetUUID(session, ref)
+		if err != nil {
+			return uuid, errors.New("unable to get VM UUID. " + err.Error())
+		}
+		return uuid, nil
+	}
+	return "", nil
+}
+
+func getUUIDFromVMApplianceRef(session *xenapi.Session, ref xenapi.VMApplianceRef) (string, error) {
+	if string(ref) != "" && string(ref) != "OpaqueRef:NULL" {
+		uuid, err := xenapi.VMAppliance.GetUUID(session, ref)
+		if err != nil {
+			return uuid, errors.New("unable to get VM appliance UUID. " + err.Error())
+		}
+		return uuid, nil
+	}
+	return "", nil
+}
+
+func getVMGroupUUIDs(session *xenapi.Session, refs []xenapi.VMGroupRef) ([]string, error) {
+	uuids := []string{}
+	for _, ref := range refs {
+		uuid, err := getUUIDFromVMGroupRef(session, ref)
+		if err != nil {
+			return uuids, err
+		}
+		if uuid != "" {
+			uuids = append(uuids, uuid)
+		}
+	}
+	return uuids, nil
+}
+
+func getUUIDFromVMGroupRef(session *xenapi.Session, ref xenapi.VMGroupRef) (string, error) {
+	if string(ref) != "" && string(ref) != "OpaqueRef:NULL" {
+		uuid, err := xenapi.VMGroup.GetUUID(session, ref)
+		if err != nil {
+			return uuid, errors.New("unable to get VM group UUID. " + err.Error())
+		}
+		return uuid, nil
+	}
+	return "", nil
+}
+
+func getUUIDFromVMPPRef(session *xenapi.Session, ref xenapi.VMPPRef) (string, error) {
+	if string(ref) != "" && string(ref) != "OpaqueRef:NULL" {
+		uuid, err := xenapi.VMPP.GetUUID(session, ref)
+		if err != nil {
+			return uuid, errors.New("unable to get VMPP UUID. " + err.Error())
+		}
+		return uuid, nil
+	}
+	return "", nil
+}
+
+func getUUIDFromVMSSRef(session *xenapi.Session, ref xenapi.VMSSRef) (string, error) {
+	if string(ref) != "" && string(ref) != "OpaqueRef:NULL" {
+		uuid, err := xenapi.VMSS.GetUUID(session, ref)
+		if err != nil {
+			return uuid, errors.New("unable to get VMSS UUID. " + err.Error())
+		}
+		return uuid, nil
+	}
+	return "", nil
+}
+
+func getUUIDFromVMMetricsRef(session *xenapi.Session, ref xenapi.VMMetricsRef) (string, error) {
+	if string(ref) != "" && string(ref) != "OpaqueRef:NULL" {
+		uuid, err := xenapi.VMMetrics.GetUUID(session, ref)
+		if err != nil {
+			return uuid, errors.New("unable to get VM metrics UUID. " + err.Error())
+		}
+		return uuid, nil
+	}
+	return "", nil
+}
+
+func getUUIDFromVMGuestMetricsRef(session *xenapi.Session, ref xenapi.VMGuestMetricsRef) (string, error) {
+	if string(ref) != "" && string(ref) != "OpaqueRef:NULL" {
+		uuid, err := xenapi.VMGuestMetrics.GetUUID(session, ref)
+		if err != nil {
+			return uuid, errors.New("unable to get VM guest metrics UUID. " + err.Error())
+		}
+		return uuid, nil
+	}
+	return "", nil
+}
+
+func getVTPMUUIDs(session *xenapi.Session, refs []xenapi.VTPMRef) ([]string, error) {
+	uuids := []string{}
+	for _, ref := range refs {
+		uuid, err := getUUIDFromVTPMRef(session, ref)
+		if err != nil {
+			return uuids, err
+		}
+		if uuid != "" {
+			uuids = append(uuids, uuid)
+		}
+	}
+	return uuids, nil
+}
+
+func getUUIDFromVTPMRef(session *xenapi.Session, ref xenapi.VTPMRef) (string, error) {
+	if string(ref) != "" && string(ref) != "OpaqueRef:NULL" {
+		uuid, err := xenapi.VTPM.GetUUID(session, ref)
+		if err != nil {
+			return uuid, errors.New("unable to get VTPM UUID. " + err.Error())
+		}
+		return uuid, nil
+	}
+	return "", nil
+}
+
+func getVUSBUUIDs(session *xenapi.Session, refs []xenapi.VUSBRef) ([]string, error) {
+	uuids := []string{}
+	for _, ref := range refs {
+		uuid, err := getUUIDFromVUSBRef(session, ref)
+		if err != nil {
+			return uuids, err
+		}
+		if uuid != "" {
+			uuids = append(uuids, uuid)
+		}
+	}
+	return uuids, nil
+}
+
+func getUUIDFromVUSBRef(session *xenapi.Session, ref xenapi.VUSBRef) (string, error) {
+	if string(ref) != "" && string(ref) != "OpaqueRef:NULL" {
+		uuid, err := xenapi.VUSB.GetUUID(session, ref)
+		if err != nil {
+			return uuid, errors.New("unable to get VUSB UUID. " + err.Error())
+		}
+		return uuid, nil
+	}
+	return "", nil
+}

--- a/xenserver/vdi_utils.go
+++ b/xenserver/vdi_utils.go
@@ -134,9 +134,9 @@ func getVDICreateParams(ctx context.Context, session *xenapi.Session, data vdiRe
 
 func updateVDIResourceModel(ctx context.Context, session *xenapi.Session, record xenapi.VDIRecord, data *vdiResourceModel) error {
 	data.NameLabel = types.StringValue(record.NameLabel)
-	srUUID, err := xenapi.SR.GetUUID(session, record.SR)
+	srUUID, err := getUUIDFromSRRef(session, record.SR)
 	if err != nil {
-		return errors.New(err.Error())
+		return err
 	}
 	data.SR = types.StringValue(srUUID)
 	data.VirtualSize = types.Int64Value(int64(record.VirtualSize))

--- a/xenserver/vm_data_source.go
+++ b/xenserver/vm_data_source.go
@@ -66,7 +66,7 @@ func vmDataSchema() map[string]schema.Attribute {
 			Computed:            true,
 		},
 		"suspend_vdi": schema.StringAttribute{
-			MarkdownDescription: "The VDI that a suspend image is stored on. Only has meaning if VM is currently suspended.",
+			MarkdownDescription: "The VDI(UUID) that a suspend image is stored on. Only has meaning if VM is currently suspended.",
 			Computed:            true,
 		},
 		"memory_overhead": schema.Int64Attribute{
@@ -105,11 +105,11 @@ func vmDataSchema() map[string]schema.Attribute {
 			Computed:            true,
 		},
 		"resident_on": schema.StringAttribute{
-			MarkdownDescription: "The host the VM is currently resident on.",
+			MarkdownDescription: "The host(UUID) the VM is currently resident on.",
 			Computed:            true,
 		},
 		"scheduled_to_be_resident_on": schema.StringAttribute{
-			MarkdownDescription: "The host on which the VM is due to be started/resumed/migrated. This acts as a memory reservation indicator.",
+			MarkdownDescription: "The host(UUID) on which the VM is due to be started/resumed/migrated. This acts as a memory reservation indicator.",
 			Computed:            true,
 		},
 		"affinity": schema.StringAttribute{
@@ -161,32 +161,32 @@ func vmDataSchema() map[string]schema.Attribute {
 			Computed:            true,
 		},
 		"consoles": schema.ListAttribute{
-			MarkdownDescription: "Virtual console devices.",
+			MarkdownDescription: "The UUID list of virtual console devices.",
 			Computed:            true,
 			ElementType:         types.StringType,
 		},
 		"vifs": schema.ListAttribute{
-			MarkdownDescription: "Virtual network interfaces.",
+			MarkdownDescription: "The UUID list of virtual network interfaces.",
 			Computed:            true,
 			ElementType:         types.StringType,
 		},
 		"vbds": schema.ListAttribute{
-			MarkdownDescription: "Virtual block devices.",
+			MarkdownDescription: "The UUID list of virtual block devices.",
 			Computed:            true,
 			ElementType:         types.StringType,
 		},
 		"vusbs": schema.ListAttribute{
-			MarkdownDescription: "Virtual USB devices.",
+			MarkdownDescription: "The UUID list of virtual USB devices.",
 			Computed:            true,
 			ElementType:         types.StringType,
 		},
 		"crash_dumps": schema.ListAttribute{
-			MarkdownDescription: "Crash dumps associated with this VM.",
+			MarkdownDescription: "The UUID list of crash dumps associated with this VM.",
 			Computed:            true,
 			ElementType:         types.StringType,
 		},
 		"vtpms": schema.ListAttribute{
-			MarkdownDescription: "Virtual TPMs.",
+			MarkdownDescription: "The UUID list of virtual TPMs.",
 			Computed:            true,
 			ElementType:         types.StringType,
 		},
@@ -241,11 +241,11 @@ func vmDataSchema() map[string]schema.Attribute {
 			ElementType:         types.StringType,
 		},
 		"metrics": schema.StringAttribute{
-			MarkdownDescription: "Metrics associated with this VM.",
+			MarkdownDescription: "Metrics(UUID) associated with this VM.",
 			Computed:            true,
 		},
 		"guest_metrics": schema.StringAttribute{
-			MarkdownDescription: "Metrics associated with the running guest.",
+			MarkdownDescription: "Metrics(UUID) associated with the running guest.",
 			Computed:            true,
 		},
 		"last_booted_record": schema.StringAttribute{
@@ -274,11 +274,11 @@ func vmDataSchema() map[string]schema.Attribute {
 			Computed:            true,
 		},
 		"snapshot_of": schema.StringAttribute{
-			MarkdownDescription: "Ref pointing to the VM this snapshot is of.",
+			MarkdownDescription: "UUID pointing to the VM this snapshot is of.",
 			Computed:            true,
 		},
 		"snapshots": schema.ListAttribute{
-			MarkdownDescription: "List pointing to all the VM snapshots.",
+			MarkdownDescription: "UUID list pointing to all the VM snapshots.",
 			Computed:            true,
 			ElementType:         types.StringType,
 		},
@@ -291,7 +291,7 @@ func vmDataSchema() map[string]schema.Attribute {
 			Computed:            true,
 		},
 		"blobs": schema.MapAttribute{
-			MarkdownDescription: "Binary blobs associated with this VM.",
+			MarkdownDescription: "Binary blobs(UUID) associated with this VM.",
 			Computed:            true,
 			ElementType:         types.StringType,
 		},
@@ -315,11 +315,11 @@ func vmDataSchema() map[string]schema.Attribute {
 			Computed:            true,
 		},
 		"parent": schema.StringAttribute{
-			MarkdownDescription: "Ref pointing to the parent of this VM.",
+			MarkdownDescription: "UUID pointing to the parent of this VM.",
 			Computed:            true,
 		},
 		"children": schema.ListAttribute{
-			MarkdownDescription: "List pointing to all the children of this VM.",
+			MarkdownDescription: "UUID list pointing to all the children of this VM.",
 			Computed:            true,
 			ElementType:         types.StringType,
 		},
@@ -329,7 +329,7 @@ func vmDataSchema() map[string]schema.Attribute {
 			ElementType:         types.StringType,
 		},
 		"protection_policy": schema.StringAttribute{
-			MarkdownDescription: "Ref pointing to a protection policy for this VM.",
+			MarkdownDescription: "UUID pointing to a protection policy for this VM.",
 			Computed:            true,
 		},
 		"is_snapshot_from_vmpp": schema.BoolAttribute{
@@ -337,7 +337,7 @@ func vmDataSchema() map[string]schema.Attribute {
 			Computed:            true,
 		},
 		"snapshot_schedule": schema.StringAttribute{
-			MarkdownDescription: "Ref pointing to a snapshot schedule for this VM.",
+			MarkdownDescription: "UUID pointing to a snapshot schedule for this VM.",
 			Computed:            true,
 		},
 		"is_vmss_snapshot": schema.BoolAttribute{
@@ -345,7 +345,7 @@ func vmDataSchema() map[string]schema.Attribute {
 			Computed:            true,
 		},
 		"appliance": schema.StringAttribute{
-			MarkdownDescription: "The appliance to which this VM belongs.",
+			MarkdownDescription: "The appliance(UUID) to which this VM belongs.",
 			Computed:            true,
 		},
 		"start_delay": schema.Int64Attribute{
@@ -361,17 +361,17 @@ func vmDataSchema() map[string]schema.Attribute {
 			Computed:            true,
 		},
 		"vgpus": schema.ListAttribute{
-			MarkdownDescription: "Virtual GPUs.",
+			MarkdownDescription: "The UUID list of virtual GPUs.",
 			Computed:            true,
 			ElementType:         types.StringType,
 		},
 		"attached_pcis": schema.ListAttribute{
-			MarkdownDescription: "Currently passed-through PCI devices.",
+			MarkdownDescription: "The UUID list of currently passed-through PCI devices.",
 			Computed:            true,
 			ElementType:         types.StringType,
 		},
 		"suspend_sr": schema.StringAttribute{
-			MarkdownDescription: "The SR on which a suspend image is stored.",
+			MarkdownDescription: "The SR(UUID) on which a suspend image is stored.",
 			Computed:            true,
 		},
 		"version": schema.Int32Attribute{
@@ -419,6 +419,11 @@ func vmDataSchema() map[string]schema.Attribute {
 		},
 		"pending_guidances_full": schema.ListAttribute{
 			MarkdownDescription: "The set of pending full guidances after applying updates, which a user should follow to make some updates, for example, specific hardware drivers or CPU features, fully effective, but the 'average user' doesn't need to.",
+			Computed:            true,
+			ElementType:         types.StringType,
+		},
+		"groups": schema.ListAttribute{
+			MarkdownDescription: "The UUID list of VM groups associated with the VM.",
 			Computed:            true,
 			ElementType:         types.StringType,
 		},
@@ -497,7 +502,7 @@ func (d *vmDataSource) Read(ctx context.Context, req datasource.ReadRequest, res
 		}
 
 		var vmItem vmRecordData
-		err := updateVMRecordData(ctx, vmRecord, &vmItem)
+		err := updateVMRecordData(ctx, d.session, vmRecord, &vmItem)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Unable to update VM data",


### PR DESCRIPTION
test result:
```
ubuntu@ubuntu-server:~/code/terraform-provider-xenserver$ make testacc
if [ -z "/home/ubuntu/go/bin" ]; then echo "GOBIN is not set" && exit 1; fi
rm -f /home/ubuntu/go/bin/terraform-provider-xenserver
go mod tidy
go install .
md5sum /home/ubuntu/go/bin/terraform-provider-xenserver
47f2225dd980e772e3108a3ee02f3e90  /home/ubuntu/go/bin/terraform-provider-xenserver
source .env \
    && TF_ACC=1 go test -v  -timeout 60m ./xenserver/ \
    && TF_ACC=1 TEST_POOL=1 go test -v -run TestAccPoolResource -timeout 60m ./xenserver/
=== RUN   TestAccHostDataSource
--- PASS: TestAccHostDataSource (13.28s)
=== RUN   TestAccNetworkDataSource
--- PASS: TestAccNetworkDataSource (6.56s)
=== RUN   TestAccVlanResource
--- PASS: TestAccVlanResource (31.88s)
=== RUN   TestAccNICDataSource
--- PASS: TestAccNICDataSource (5.85s)
=== RUN   TestAccPIFConfigureResource
--- PASS: TestAccPIFConfigureResource (33.27s)
=== RUN   TestAccPifDataSource
--- PASS: TestAccPifDataSource (22.19s)
=== RUN   TestAccPoolResource
    pool_resource_test.go:89: Skipping TestAccPoolResource test due to TEST_POOL not set
--- SKIP: TestAccPoolResource (0.00s)
=== RUN   TestAccPoolManagementNetwork
    pool_resource_test.go:129: Skipping TestAccPoolManagementNetwork test due to TEST_POOL not set
--- SKIP: TestAccPoolManagementNetwork (0.00s)
=== RUN   TestAccSnapshotResource
--- PASS: TestAccSnapshotResource (59.28s)
=== RUN   TestAccSRDataSource
--- PASS: TestAccSRDataSource (6.75s)
=== RUN   TestAccNFSResource
--- PASS: TestAccNFSResource (29.51s)
=== RUN   TestAccNFSISOResource
--- PASS: TestAccNFSISOResource (23.49s)
=== RUN   TestAccSRResourceLocal
--- PASS: TestAccSRResourceLocal (37.77s)
=== RUN   TestAccSRResourceShared
--- PASS: TestAccSRResourceShared (23.04s)
=== RUN   TestAccSMBResource
--- PASS: TestAccSMBResource (23.58s)
=== RUN   TestAccSMBISOResource
--- PASS: TestAccSMBISOResource (23.36s)
=== RUN   TestAccVDIResource
--- PASS: TestAccVDIResource (36.22s)
=== RUN   TestAccVMDataSource
--- PASS: TestAccVMDataSource (22.57s)
=== RUN   TestAccVMResource
--- PASS: TestAccVMResource (63.07s)
=== RUN   TestAccLinuxVMResource
--- PASS: TestAccLinuxVMResource (21.24s)
PASS
ok      terraform-provider-xenserver/xenserver  482.939s
``` 