### PR TITLE
 CP-311607 Replace MIT License with Mozilla Public License Version 2.0 in LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,25 +1,358 @@
-The MIT License (MIT)
+Mozilla Public License Version 2.0
+==================================
 
-Copyright (c) 2024 Cloud Software Group, Inc.
+1. Definitions
+--------------
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+1.1. "Contributor"
+	means each individual or legal entity that creates, contributes to
+	the creation of, or owns Covered Software.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+1.2. "Contributor Version"
+	means the combination of the Contributions of others (if any) used
+	by a Contributor and that particular Contributor's Contribution.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+1.3. "Contribution"
+	means Covered Software of a particular Contributor.
 
-Except as contained in this notice, the name of Cloud Software Group shall not
-be used in advertising or otherwise to promote the sale, use or other dealings
-in this Software without prior written authorization from Cloud Software Group.
+1.4. "Covered Software"
+	means Source Code Form to which the initial Contributor has attached
+	the notice in Exhibit A, the Executable Form of such Source Code Form,
+	and Modifications of such Source Code Form, in each case including
+	portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+	means
+
+	(a) that the initial Contributor has attached the notice described
+		in Exhibit B to the Covered Software; or
+
+	(b) that the Covered Software was made available under the terms of
+		version 1.1 or earlier of the License, but not also under the
+		terms of a Secondary License.
+
+1.6. "Executable Form"
+	means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+	means a work that combines Covered Software with other material, in
+	a separate file or files, that is not Covered Software.
+
+1.8. "License"
+	means this document.
+
+1.9. "Licensable"
+	means having the right to grant, to the maximum extent possible,
+	whether at the time of the initial grant or subsequently, any and
+	all of the rights conveyed by this License.
+
+1.10. "Modifications"
+	means any of the following:
+
+	(a) any file in Source Code Form that results from an addition to,
+		deletion from, or modification of the contents of Covered
+		Software; or
+
+	(b) any new file in Source Code Form that contains any Covered
+		Software.
+
+1.11. "Patent Claims" of a Contributor
+	means any patent claim(s), including without limitation, method,
+	process, and apparatus claims, in any patent Licensable by such
+	Contributor that would be infringed, but for the grant of the License,
+	by the making, using, selling, offering for sale, having made, import,
+	or transfer of either its Contributions or its Contributor Version.
+
+1.12. "Secondary License"
+	means either the GNU General Public License, Version 2.0, the GNU
+	Lesser General Public License, Version 2.1, the GNU Affero General
+	Public License, Version 3.0, or any later versions of those licenses.
+
+1.13. "Source Code Form"
+	means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+	means an individual or a legal entity exercising rights under this
+	License. For legal entities, "You" includes any entity that controls,
+	is controlled by, or is under common control with You. For purposes of
+	this definition, "control" means (a) the power, direct or indirect, to
+	cause the direction or management of such entity, whether by contract
+	or otherwise, or (b) ownership of more than fifty percent (50%) of the
+	outstanding shares or beneficial ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+	Licensable by such Contributor to use, reproduce, make available,
+	modify, display, perform, distribute, and otherwise exploit its
+	Contributions, either on an unmodified basis, with Modifications, or
+	as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer for
+	sale, have made, import, and otherwise transfer either its
+	Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software; or
+
+(b) for infringements caused by: (i) Your and any other third party's
+	modifications of Covered Software, or (ii) the combination of its
+	Contributions with other software (except as part of its Contributor
+	Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+	its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights to
+grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code Form,
+	as described in Section 3.1, and You must inform recipients of the
+	Executable Form how they can obtain a copy of such Source Code Form by
+	reasonable means in a timely manner, at a charge no more than the cost
+	of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+	License, or sublicense it under different terms, provided that the
+	license for the Executable Form does not attempt to limit or alter the
+	recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of the
+Larger Work may, at their option, further distribute the Covered Software
+under the terms of either this License or such Secondary License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty, or
+limitations of liability) contained within the Source Code Form of the
+Covered Software, except that You may alter any license notices to the
+extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity, or liability terms You offer.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with the
+terms of this License to the maximum extent possible; and (b) describe
+the limitations and the code they affect. Such description must be placed
+in a text file included with all distributions of the Covered Software
+under this License. Except to the extent prohibited by statute or
+regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions, counter-
+claims, and cross-claims) alleging that a Contributor Version directly or
+indirectly infringes any patent, then the rights granted to You by this
+License for the Covered Software shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end
+user license agreements (excluding distributors and resellers) which have
+been validly granted by You or Your distributors under this License prior
+to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"        *
+*  basis, without warranty of any kind, either expressed, implied, or   *
+*  statutory, including, without limitation, warranties that the        *
+*  Covered Software is free of defects, merchantable, fit for a         *
+*  particular purpose or non-infringing. The entire risk as to the      *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You      *
+*  (not any Contributor) assume the cost of any necessary servicing,    *
+*  repair, or correction. This disclaimer of warranty constitutes an    *
+*  essential part of this License. No use of any Covered Software is    *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,          *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party       *
+*  shall have been informed of the possibility of such damages. This    *
+*  limitation of liability shall not apply to liability for death or    *
+*  personal injury resulting from such party's negligence to the        *
+*  extent applicable law prohibits such limitation. Some jurisdictions  *
+*  do not allow the exclusion or limitation of incidental or            *
+*  consequential damages, so this exclusion and limitation may not      *
+*  apply to You.                                                       *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a modified
+version of this License if you rename the license and remove any
+references to the name of the license steward (except to note that such
+modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/README.md
+++ b/README.md
@@ -136,4 +136,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## License
 
-See [LICENSE.md](LICENSE.md)
+The source code in this repository is licensed under the Mozilla Public License 2.0 (MPL-2.0). See [LICENSE.md](LICENSE.md).
+
+Third-party software notices and dependency guidance for source code are documented in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,15 @@
+# Third-Party Notices
+
+The source code in this repository is licensed under the Mozilla Public License 2.0 (MPL-2.0). See [LICENSE.md](LICENSE.md).
+
+## Bundled Third-Party Code
+
+This repository does not bundle or vendor third-party source code.
+
+## Build-Time Dependencies
+
+Third-party Go module dependencies are resolved at build time and are listed in [go.mod](go.mod) and [go.sum](go.sum). Each dependency is distributed under its own license by its respective copyright holder.
+
+## XenServer SDK
+
+The XenServer SDK is not distributed with this repository. It must be obtained separately by users during setup as described in [README.md](README.md).

--- a/main.go
+++ b/main.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package main
 
 import (

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //go:build tools
 
 package tools

--- a/xenserver/host_data_source.go
+++ b/xenserver/host_data_source.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/host_data_source_test.go
+++ b/xenserver/host_data_source_test.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/host_utils.go
+++ b/xenserver/host_utils.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/network_data_source.go
+++ b/xenserver/network_data_source.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/network_data_source_test.go
+++ b/xenserver/network_data_source_test.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/network_utils.go
+++ b/xenserver/network_utils.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/network_vlan_resource.go
+++ b/xenserver/network_vlan_resource.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/network_vlan_resource_test.go
+++ b/xenserver/network_vlan_resource_test.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/nic_data_source.go
+++ b/xenserver/nic_data_source.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/nic_data_source_test.go
+++ b/xenserver/nic_data_source_test.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/pif_configure_resource.go
+++ b/xenserver/pif_configure_resource.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/pif_configure_resource_test.go
+++ b/xenserver/pif_configure_resource_test.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/pif_data_source.go
+++ b/xenserver/pif_data_source.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/pif_data_source_test.go
+++ b/xenserver/pif_data_source_test.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/pif_utils.go
+++ b/xenserver/pif_utils.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/pool_resource.go
+++ b/xenserver/pool_resource.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/pool_resource_test.go
+++ b/xenserver/pool_resource_test.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/pool_utils.go
+++ b/xenserver/pool_utils.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/provider.go
+++ b/xenserver/provider.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/provider_test.go
+++ b/xenserver/provider_test.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/snapshot_resource.go
+++ b/xenserver/snapshot_resource.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/snapshot_resource_test.go
+++ b/xenserver/snapshot_resource_test.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/snapshot_utils.go
+++ b/xenserver/snapshot_utils.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/sr_data_source.go
+++ b/xenserver/sr_data_source.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/sr_data_source_test.go
+++ b/xenserver/sr_data_source_test.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/sr_nfs_resource.go
+++ b/xenserver/sr_nfs_resource.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/sr_nfs_resource_test.go
+++ b/xenserver/sr_nfs_resource_test.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/sr_resource.go
+++ b/xenserver/sr_resource.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/sr_resource_test.go
+++ b/xenserver/sr_resource_test.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/sr_smb_resource.go
+++ b/xenserver/sr_smb_resource.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/sr_smb_resource_test.go
+++ b/xenserver/sr_smb_resource_test.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/sr_utils.go
+++ b/xenserver/sr_utils.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/uuid_utils.go
+++ b/xenserver/uuid_utils.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/vbd_utils.go
+++ b/xenserver/vbd_utils.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/vdi_resource.go
+++ b/xenserver/vdi_resource.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/vdi_resource_test.go
+++ b/xenserver/vdi_resource_test.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/vdi_utils.go
+++ b/xenserver/vdi_utils.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/vif_utils.go
+++ b/xenserver/vif_utils.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/vm_data_source.go
+++ b/xenserver/vm_data_source.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/vm_data_source_test.go
+++ b/xenserver/vm_data_source_test.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/vm_resouce.go
+++ b/xenserver/vm_resouce.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/vm_resource_test.go
+++ b/xenserver/vm_resource_test.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (

--- a/xenserver/vm_utils.go
+++ b/xenserver/vm_utils.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package xenserver
 
 import (


### PR DESCRIPTION
CP-311607 Add MPL 2.0 per-file license headers and third-party notices

- Replace MIT license with Mozilla Public License 2.0 in LICENSE.md
- Add MPL 2.0 Exhibit A header to all .go source files (main.go,
  tools/tools.go, and all xenserver/*.go files) as required by
  Section 3.1 for per-file copyleft protection
- Update README.md License section to reference MPL-2.0 explicitly
- Add THIRD_PARTY_NOTICES.md documenting dependency licensing